### PR TITLE
add init_env function & improve split_outside quotes

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -1,11 +1,22 @@
 #ifndef MINISHELL_H
 # define MINISHELL_H
 /* helper functions to prototype*/
+#include "struct.h"
 int while_d(const char *s, int (*)(int), int is_true, int *index);
 int while_i(const char *s, int (*)(int), int is_true, int *index);
 int	while_not_i(const char *s, int (*)(int), char c, int *index);
 int	while_is_i(const char *s, char c, int *index);
 
-// t_lexer	wrap_lexer(t_shell *shell);
+// initialize shell
+char	**init_env(const char **envp);
+t_shell	*init_shell(const char **envp);
+void	update_exit_status(t_shell *shell, int status);
+
+// parsing / tokenization
+void	get_tokens(t_shell *shell);
+void	destroy_all_tokens(t_shell *shell);
+
+int		builtin(t_shell *shell, t_token *token);
+void	execute_commands(t_shell *shell, t_token *token);
 
 #endif

--- a/src/builtins/builtins.c
+++ b/src/builtins/builtins.c
@@ -31,8 +31,9 @@ void	execute_commands(t_shell *shell, t_token *token)
 		test = fork();
 	if (test == 0)
 	{
-		if (execvp(token->cmd_args[0].elem, token->command) == -1)
-			printf("command not found\n");
+		// if (execvp(token->cmd_args[0].elem, token->command) == -1)
+		// 	printf("command not found\n");
+		execvp(token->cmd_args[0].elem, token->command);
 		destroy_all_tokens(shell);
 		exit(0);
 	}
@@ -51,7 +52,7 @@ int		builtin(t_shell *shell, t_token *token)
 	convert_tokens_to_string_array(shell->token);
 	char	buf[MAXPATHLEN + 1];
 
-	printf("my builtins:\n");
+	// printf("my builtins:\n");
 	if (!token || !token->command || !*token->command)
 		return (-1);
 	// if (!shell->owned_envp || !*(shell->owned_envp))
@@ -76,7 +77,7 @@ int		builtin(t_shell *shell, t_token *token)
 	}
 	if (occurs_exclusively("env", token->command[0]))
 		return (builtin_env(shell->owned_envp));
-	printf("builtin not found: running exec!\n");
+	// printf("builtin not found: running exec!\n");
 	execute_commands(shell, token);
 	return (0);
 }

--- a/src/builtins/builtins.c
+++ b/src/builtins/builtins.c
@@ -1,4 +1,3 @@
-#include "libft.h"
 #include "struct.h"
 #include <stdbool.h>
 #include <sys/param.h>
@@ -15,8 +14,16 @@ void	convert_split_token_string_array_to_tokens(t_shell *shell);
 void	convert_tokens_to_string_array(t_token *token);
 void	destroy_all_tokens(t_shell *shell);
 #include <sys/wait.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
 
-// atm only works for execution of one command
+/**
+ * @brief
+ * @audit atm only works for execution of one command (forbidden function)
+ * @param shell
+ * @param token pointer to element in array of tokens
+ */
 void	execute_commands(t_shell *shell, t_token *token)
 {
 	pid_t test = -1;

--- a/src/builtins/echo.c
+++ b/src/builtins/echo.c
@@ -38,7 +38,7 @@ size_t	echo(const char *cmd, char **args, char **envp)
 	(void)cmd;
 	(void)envp;
 	// print_arr(args + 2);
-	printf("echo builtin gets called\n");
+	// printf("echo builtin gets called\n");
 	if (!args || !*args)
 		return (write(1, "\n", 1));
 	if (!occurs_exclusively("echo", *args))

--- a/src/builtins/env.c
+++ b/src/builtins/env.c
@@ -7,7 +7,7 @@ int	builtin_env(char **envp)
 	int	i = 0;
 	if (!envp || !*(envp))
 	{
-		printf("fatal error\n");
+		// printf("fatal error\n");
 		return (1);
 	}
 	while (envp[i + 1])

--- a/src/builtins/exit.c
+++ b/src/builtins/exit.c
@@ -9,7 +9,7 @@ void	builtin_exit(t_shell *shell)
 	exit_code = 0;
 	if (shell->line)
 		free_null(shell->line);
-	printf("exiting now...\n");
+	// printf("exiting now...\n");
 	if (shell->owned_envp)
 		arr_free(shell->owned_envp);
 	size_t	i = 0;

--- a/src/builtins/export.c
+++ b/src/builtins/export.c
@@ -24,20 +24,21 @@ int	export(t_shell *shell, t_token *token)
 	if (*token->command && token->command + 1 && *(token->command + 1)
 		&& str_cchr(*(token->command + 1), '=') == 1 && arr_len((const char **)token->command) == 2)
 	{
-		printf("gets to export: %s\n", *(token->command + 1));
+		// printf("gets to export: %s\n", *(token->command + 1));
 		if (!check_valid_key(*(token->command + 1)))
-			return ((void)printf("invalid variable name\n"), -1);
+			return (-1);
+		// (void)printf("invalid variable name\n")
 		shell->tmp_arr = export_var(shell->owned_envp, *(token->command + 1));
 		if (!shell->tmp_arr)
-			return ((void)printf("add_env failed\n"), -1);
+			return (-1);
 		arr_free(shell->owned_envp);
 		shell->owned_envp = shell->tmp_arr;
 		shell->tmp_arr = NULL;
 		return (0);
 	}
-	if (arr_len((const char **)token->command) > 2)
-		printf("Error: too many arguments!\n");
-	else
-		printf("export failed\n");
+	// if (arr_len((const char **)token->command) > 2)
+	// 	printf("Error: too many arguments!\n");
+	// else
+	// 	printf("export failed\n");
 	return (-1);
 }

--- a/src/builtins/export.c
+++ b/src/builtins/export.c
@@ -31,7 +31,8 @@ int	export(t_shell *shell, t_token *token)
 		shell->tmp_arr = export_var(shell->owned_envp, *(token->command + 1));
 		if (!shell->tmp_arr)
 			return (-1);
-		arr_free(shell->owned_envp);
+		if (shell->owned_envp != shell->tmp_arr)
+			arr_free(shell->owned_envp);
 		shell->owned_envp = shell->tmp_arr;
 		shell->tmp_arr = NULL;
 		return (0);

--- a/src/builtins/unset.c
+++ b/src/builtins/unset.c
@@ -12,7 +12,8 @@ int		unset(char *cmd, char **args, char **envp)
 
 	// key should be at args[1]
 	if (!envp)
-		return ((void)printf("Error: environment does not exist!\n"), -2);
+		return (-2);
+		// return ((void)printf("Error: environment does not exist!\n"), -2);
 	if (!args || !*args || arr_len((const char **)args) > 2)
 		return ((void)printf("Error: no variable name provided!\n"), -1);
 	if (!occurs_exclusively("unset", cmd)
@@ -20,15 +21,16 @@ int		unset(char *cmd, char **args, char **envp)
 		return ((void)printf("Error: no variable name provided!\n"), -1);
 	key = args[1];
 	if (!key || !*key)
-		return ((void)printf("Error: no variable name provided!\n"), -1);
+		return (0);
+		// return ((void)printf("Error: no variable name provided!\n"), -1);
 	index = find_key_env((const char **)envp, key, ft_strlen);
 	if (index >= 0 && envp[index])
 	{
-		printf("removing variable: %s\n", envp[index]);
+		// printf("removing variable: %s\n", envp[index]);
 		rm_str_arr(envp, envp[index]);
 		return (0);
 	}
-	printf("Error: varname does not exist in env!\n");
+	// printf("Error: varname does not exist in env!\n");
 	return (-1);
 }
 // int		unset(t_shell *shell, char *key)

--- a/src/environment/export_var.c
+++ b/src/environment/export_var.c
@@ -9,6 +9,28 @@
 
 #include "utils.h"
 
+// search for key
+// make it key=value if it exists
+void	update_variable(char **envp, const char *key, const char *value)
+{
+	char	*key_value;
+	char	*tmp;
+	int		index;
+
+	index = find_key_env((const char **)envp, key, ft_strlen);
+	if (index == -1)
+		return ;// error handling?
+	tmp = ft_strjoin(key, "=");
+	if (!tmp)
+		return ;
+	key_value = ft_strjoin(tmp, value);
+	free(tmp);
+	if (!key_value)
+		return ;
+	free(envp[index]);
+	envp[index] = key_value;
+}
+
 // input like key=val
 char	**export_var(char **arr, const char *s)
 {

--- a/src/environment/export_var.c
+++ b/src/environment/export_var.c
@@ -41,7 +41,8 @@ char	**export_var(char **arr, const char *s)
 		return (NULL);
 	int	index = find_key_env((const char **)arr, s, get_key_len);
 	if (!arr)
-		return (printf("environment does not exist!\n"), NULL);
+		return (NULL);
+		// return (printf("environment does not exist!\n"), NULL);
 	if (index == -1)
 	{
 		tmp = append_str_arr((const char **)arr, s);
@@ -51,7 +52,8 @@ char	**export_var(char **arr, const char *s)
 	}
 	s_tmp = ft_strdup(s);
 	if (!s_tmp)
-		return (printf("error exporting variable\n"), NULL);
+		return (NULL);
+		// return (printf("error exporting variable\n"), NULL);
 	free(arr[index]);
 	arr[index] = s_tmp;
 	return (arr);

--- a/src/environment/find_key.c
+++ b/src/environment/find_key.c
@@ -27,7 +27,7 @@ int	find_key_env(const char **arr, const char *s, size_t (*f)(const char *s))
 		return (-1);
 	while (arr[i])
 	{
-		if (ft_strncmp(arr[i], s, key_len - 1) == 0
+		if (ft_strncmp(arr[i], s, key_len) == 0
 			&& arr[i][key_len] && arr[i][key_len] == '=')
 				return (i);
 		i++;
@@ -55,7 +55,7 @@ char	*get_var_val(const char **arr, const char *key)
 			return (NULL);
 		val = ft_substr(arr[index], ft_strlen(key_eq), ft_strlen(arr[index]) - ft_strlen(key_eq));
 		fprintf(stderr, "val: %s\n", val);
-		free_null(key_eq);
+		free(key_eq);
 		if (!val)
 			return (NULL);
 		return (val);

--- a/src/environment/find_key.c
+++ b/src/environment/find_key.c
@@ -50,11 +50,11 @@ char	*get_var_val(const char **arr, const char *key)
 	if (index != -1 && arr[index])
 	{
 		key_eq = ft_strjoin(key, "=");
-		fprintf(stderr, "key_eq: '%s'\n", key_eq);
+		// fprintf(stderr, "key_eq: '%s'\n", key_eq);
 		if (!key_eq)
 			return (NULL);
 		val = ft_substr(arr[index], ft_strlen(key_eq), ft_strlen(arr[index]) - ft_strlen(key_eq));
-		fprintf(stderr, "val: %s\n", val);
+		// fprintf(stderr, "val: %s\n", val);
 		free(key_eq);
 		if (!val)
 			return (NULL);

--- a/src/expander/expand_variables.c
+++ b/src/expander/expand_variables.c
@@ -35,7 +35,7 @@ static char *replacer(t_expander *x, const char **envp)
 		free(x->line);
 		if (!x->remainder_line)
 			return (x->ret);
-		printf("remainder: %s\n", x->remainder_line);
+		// printf("remainder: %s\n", x->remainder_line);
 		x->tmp = ft_strjoin(x->ret, x->remainder_line);
 		free(x->remainder_line);
 		free(x->ret);

--- a/src/expander/expand_variables.c
+++ b/src/expander/expand_variables.c
@@ -72,11 +72,14 @@ static char	*check_line(t_expander *x, const char **envp)
 		else if (x->line[x->i] == '\'' && x->singlequote == x->line[x->i])
 			x->singlequote = 0;
 		else if (x->line[x->i] && x->line[x->i + 1] && x->line[x->i] == '$'
-			&& x->singlequote == 0 && is_valid_key(x->line[x->i + 1]))
+			&& x->singlequote == 0 && (is_valid_key(x->line[x->i + 1]) || x->line[x->i + 1] == '?'))
 		{
 			x->i++;
 			x->start = x->i;
-			while (x->line[x->i] && is_valid_key(x->line[x->i]))
+			if (x->line[x->i] != '?')
+				while (x->line[x->i] && is_valid_key(x->line[x->i]))
+					x->i++;
+			else
 				x->i++;
 			if (x->start == x->i)
 				continue;

--- a/src/init.c
+++ b/src/init.c
@@ -9,7 +9,7 @@ char	**init_env(const char **envp)
 
 	if (!envp)
 		return (NULL);
-	env = append_str_arr(envp, "$?=0");
+	env = append_str_arr(envp, "?=0");
 	if (!env)
 		return (NULL);
 	return (env);
@@ -39,7 +39,7 @@ void	update_exit_status(t_shell *shell, int status)
 	status_str = ft_itoa(status);
 	if (!status_str)
 		return ;
-	new_status = ft_strjoin("$?=", status_str);
+	new_status = ft_strjoin("?=", status_str);
 	free(status_str);
 	if (!new_status)
 		return ;

--- a/src/init.c
+++ b/src/init.c
@@ -1,0 +1,53 @@
+#include "struct.h"
+#include "libft.h"
+#include "utils.h"
+#include "environment.h"
+
+char	**init_env(const char **envp)
+{
+	char	**env;
+
+	if (!envp)
+		return (NULL);
+	env = append_str_arr(envp, "$?=0");
+	if (!env)
+		return (NULL);
+	return (env);
+}
+
+t_shell	*init_shell(const char **envp)
+{
+	t_shell	*shell;
+
+	shell = (t_shell *)ft_calloc(1, sizeof(t_shell));
+	if (!shell)
+		return (NULL);
+	shell->owned_envp = init_env(envp);
+	if (!shell->owned_envp)
+	{
+		free(shell);
+		return (NULL);
+	}
+	return (shell);
+}
+
+void	update_exit_status(t_shell *shell, int status)
+{
+	char	*status_str;
+	char	*new_status;
+
+	status_str = ft_itoa(status);
+	if (!status_str)
+		return ;
+	new_status = ft_strjoin("$?=", status_str);
+	free(status_str);
+	if (!new_status)
+		return ;
+	shell->tmp_arr = export_var(shell->owned_envp, new_status);
+	if (!shell->tmp_arr)
+	{
+		free(status_str);
+		free(new_status);
+		return ;
+	}
+}

--- a/src/lexer/check_quotes.c
+++ b/src/lexer/check_quotes.c
@@ -2,36 +2,36 @@
 #include "libft.h"
 #include "struct.h"
 
-void debug_print_table(const char *s, const bool *arr) {
-	if (!s || !arr)
-		return ;
-	for (int i = 0; i <= (int)strlen(s); i++){
-		fprintf(stderr, "i: [%d]: %d, %c\n", i, arr[i], s[i]);
-	}
-	for (int i = 0; i <= (int)strlen(s); i++){
-		if (arr[i] == true)
-			fprintf(stderr, "%d", arr[i]);
-		else
-			fprintf(stderr, "%d", arr[i]);
-	}
-	fprintf(stderr,"\n");
-}
+// void debug_print_table(const char *s, const bool *arr) {
+// 	if (!s || !arr)
+// 		return ;
+// 	for (int i = 0; i <= (int)strlen(s); i++){
+// 		fprintf(stderr, "i: [%d]: %d, %c\n", i, arr[i], s[i]);
+// 	}
+// 	for (int i = 0; i <= (int)strlen(s); i++){
+// 		if (arr[i] == true)
+// 			fprintf(stderr, "%d", arr[i]);
+// 		else
+// 			fprintf(stderr, "%d", arr[i]);
+// 	}
+// 	fprintf(stderr,"\n");
+// }
 
-void debug_print_line(const char *s, const bool *arr) {
-	if (!s || !arr)
-		return ;
-	for (int i = 0; i <= (int)strlen(s); i++){
-		fprintf(stderr, "%c", s[i]);
-	}
-	fprintf(stderr,"\n");
-	for (int i = 0; i <= (int)strlen(s); i++){
-		if (arr[i] == true)
-			fprintf(stderr, "%d", arr[i]);
-		else
-			fprintf(stderr, "%d", arr[i]);
-	}
-	fprintf(stderr,"\n");
-}
+// void debug_print_line(const char *s, const bool *arr) {
+// 	if (!s || !arr)
+// 		return ;
+// 	for (int i = 0; i <= (int)strlen(s); i++){
+// 		fprintf(stderr, "%c", s[i]);
+// 	}
+// 	fprintf(stderr,"\n");
+// 	for (int i = 0; i <= (int)strlen(s); i++){
+// 		if (arr[i] == true)
+// 			fprintf(stderr, "%d", arr[i]);
+// 		else
+// 			fprintf(stderr, "%d", arr[i]);
+// 	}
+// 	fprintf(stderr,"\n");
+// }
 
 t_lexer	ignore_quotes(const char *s, struct s_lexer *input)
 {
@@ -44,7 +44,7 @@ t_lexer	ignore_quotes(const char *s, struct s_lexer *input)
 	input->ignore = bool_arr_zeroing(ft_strlen(s));
 	range_ignore(s, input->ignore,'"');
 	range_ignore(s, input->ignore,'\'');
-	debug_print_line(s, input->ignore);
+	// debug_print_line(s, input->ignore);
 	return (LEXER_SUCCESS);
 }
 
@@ -55,7 +55,8 @@ t_lexer	check_against_ignore(const char *s, struct s_lexer *input)
 	if (!s)
 		return (LEXER_NULL);
 	if (input->ignore == NULL)
-		return (fprintf(stderr, "will result in segfault\n"), LEXER_NULL);
+		return (LEXER_NULL);
+		// return (fprintf(stderr, "will result in segfault\n"), LEXER_NULL);
 	i = 0;
 	if (input->singlequotes % 2 != 0 || input->doublequotes % 2 != 0)
 		return (LEXER_UNBALANCED_QUOTES);
@@ -72,6 +73,6 @@ t_lexer	check_against_ignore(const char *s, struct s_lexer *input)
 		}
 		i++;
 	}
-	printf("passed check_against_ignore\n");
+	// printf("passed check_against_ignore\n");
 	return (LEXER_SUCCESS);
 }

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -17,12 +17,12 @@ t_token	*lexer(t_shell *shell)
 {
 	if (lexer_checks_basic(shell->line) != LEXER_SUCCESS)
 	{
-		printf("syntax error\n");
+		// printf("syntax error\n");
 		shell->exit_status = 2;
 		return (NULL);
 	}
 	// build tokens
-	shell->split_pipes = split_outside_quotes(shell->line, '|');
+	shell->split_pipes = split_outside_quotes(shell->line, "|");
 	if (!shell->split_pipes)
 		return (NULL);
 	add_pipe_split_as_tokens(shell->split_pipes, shell);

--- a/src/main.c
+++ b/src/main.c
@@ -1,15 +1,13 @@
-#include "ft_printf.h"
-#include "libft.h"
 #include "struct.h"
 #include <readline/readline.h>
 #include <readline/history.h>
 #include <unistd.h>
 
 #include "msh_signals.h"
-void	get_tokens(t_shell *shell);
-int		builtin(t_shell *shell, t_token *token);
-void	execute_commands(t_shell *shell, t_token *token);
-void	destroy_all_tokens(t_shell *shell);
+
+#include "minishell.h"
+
+#include <stdlib.h>
 
 void	minishell_loop(t_shell *shell)
 {
@@ -29,27 +27,22 @@ void	minishell_loop(t_shell *shell)
 	}
 }
 
-int main(int ac, char **av, char **envp)
+
+int main(int ac, char **av, const char **envp)
 {
 	t_shell		*shell;
 
-	(void)ac;
-	(void)av;
-	shell = (t_shell *) ft_calloc(1, sizeof(t_shell));
-	shell->owned_envp = arr_dup((const char **)envp);
+	if (ac > 1 || av[1])
+		return (printf("do not pass arguments\n"), 1);
+	shell = init_shell(envp);
+	if (!shell)
+		return (1);
 	minishell_loop(shell);
 	return (0);
 }
 
 t_token	*lexer(t_shell *shell);
 
-void	tokenize(t_shell *shell)
-{
-	shell->token = lexer(shell);
-	if (!shell->token)
-		return ;// some exit code
-	// handle exit code for failed parsing/lexical errors
-}
 #include "utils.h"
 #include "builtins.h"
 void	get_tokens(t_shell *shell)
@@ -61,7 +54,10 @@ void	get_tokens(t_shell *shell)
 		if (occurs_exclusively("exit", shell->line))
 			return (builtin_exit(shell, 0));
 		add_history(shell->line);
-		tokenize(shell);
+		shell->token = lexer(shell);
+		if (!shell->token)
+			return ;// some exit code
+		// handle exit code for failed parsing/lexical errors
 		free(shell->line);
 	}
 }

--- a/src/main.c
+++ b/src/main.c
@@ -32,8 +32,10 @@ int main(int ac, char **av, const char **envp)
 {
 	t_shell		*shell;
 
-	if (ac > 1 || av[1])
-		return (printf("do not pass arguments\n"), 1);
+	(void)ac;
+	(void)av;
+	// if (ac > 1 || av[1])
+	// 	return (printf("do not pass arguments\n"), 1);
 	shell = init_shell(envp);
 	if (!shell)
 		return (1);

--- a/src/main.c
+++ b/src/main.c
@@ -6,24 +6,34 @@
 #include "msh_signals.h"
 
 #include "minishell.h"
-
+#include "libft.h"
 #include <stdlib.h>
 
 void	minishell_loop(t_shell *shell)
 {
 	while (1)
 	{
-		get_tokens(shell);
-		if (shell->token)
+		if (isatty(fileno(stdin)))
 		{
-			builtin(shell, shell->token);
-			destroy_all_tokens(shell);
+			get_tokens(shell);
+			if (shell->token)
+			{
+				builtin(shell, shell->token);
+				destroy_all_tokens(shell);
+			}
+			// else if (shell->exit_status == 2)
+			// 	continue;
+			// // does quitting using ctrl_d cause leaks?
+			else
+				return ;
 		}
-		else if (shell->exit_status == 2)
-			continue;
-		// does quitting using ctrl_d cause leaks?
 		else
-			return ;
+		{
+			char *line;
+			line = get_next_line(fileno(stdin));
+			shell->line = ft_strtrim(line, "\n");
+			free(line);
+		}
 	}
 }
 

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -7,6 +7,7 @@ typedef struct s_splitter
 	int		quote;
 	size_t	i;
 	size_t	start;
+	size_t	token_end;
 	size_t	len;
 	char	**ret;
 	char	*tmp;

--- a/src/signals/signals.c
+++ b/src/signals/signals.c
@@ -48,5 +48,3 @@ void	ctrl_c_handler(int sig, siginfo_t *info, void *unused)
 		rl_redisplay();
 	}
 }
-
-

--- a/src/tokenizer/build_tokens.c
+++ b/src/tokenizer/build_tokens.c
@@ -3,6 +3,7 @@
 #include "tokens.h"
 #include "utils.h"
 #include "struct.h"
+
 t_arg	*init_cmdargs(size_t size)
 {
 	t_arg	*args;
@@ -85,7 +86,7 @@ void	convert_split_token_string_array_to_tokens(t_shell *shell)
 	while (shell->token[i].split_pipes)
 	{
 		// split into command and arguments
-		shell->token[i].tmp_arr = split_outside_quotes(shell->token[i].split_pipes, ' ');
+		shell->token[i].tmp_arr = split_outside_quotes(shell->token[i].split_pipes, WHITESPACE);
 		if (!shell->token[i].tmp_arr)
 			return ;
 		len = arr_len((const char **)shell->token[i].tmp_arr);
@@ -121,8 +122,8 @@ void	convert_split_token_string_array_to_tokens(t_shell *shell)
 					return ;
 				if (ft_strncmp(tmp, shell->token[i].cmd_args[ii].elem, ft_strlen(tmp)) == 0)
 				{
-					printf("recursive expansion is the same as the original, freeing\n");
-					printf("reex: %s\n", shell->token[i].cmd_args[ii].elem);
+					// printf("recursive expansion is the same as the original, freeing\n");
+					// printf("reex: %s\n", shell->token[i].cmd_args[ii].elem);
 					free(tmp);
 					break ;
 				}

--- a/src/tokenizer/tokens.h
+++ b/src/tokenizer/tokens.h
@@ -2,6 +2,10 @@
 # define TOKENS_H
 typedef struct s_token	t_token;
 
+# ifndef WHITESPACE
+#  define WHITESPACE " \t\n\r\v\f"
+# endif
+
 enum e_arg
 {
 	STRING,

--- a/src/utils/arr_utils.c
+++ b/src/utils/arr_utils.c
@@ -29,8 +29,8 @@ char	**append_str_arr(const char **arr, const char *s)
 	ret[i] = ft_strdup(s);
 	if (!ret[i])
 		return (arr_free(ret), NULL);
-	printf("%zu(len)", len + 2);
-	print_arr_sep(ret, '{', '}');
+	// printf("%zu(len)", len + 2);
+	// print_arr_sep(ret, '{', '}');
 	return (ret);
 }
 

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -4,7 +4,7 @@
 char	*occurs(const char *big, const char *little);
 char	*occurs_exclusively(const char *expected, const char *actual);
 
-char	**split_outside_quotes(const char *to_split, char c);
+char	**split_outside_quotes(const char *to_split, const char *set);
 void	print_arr_sep(char **arr, char sep_open, char sep_close);
 char	**append_str_arr(const char **arr, const char *s);
 void	rm_str_arr(char **arr, const char *s);

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -10,6 +10,8 @@ char	**append_str_arr(const char **arr, const char *s);
 void	rm_str_arr(char **arr, const char *s);
 char	**arr_trim(char **arr, char const *set);
 
+void	update_variable(char **envp, const char *key, const char *value);
+
 # include <stddef.h>
 int		arr_ncmp(const char **arr1, const char **arr2, size_t n);
 

--- a/test/env/test_export_var.c
+++ b/test/env/test_export_var.c
@@ -5,7 +5,6 @@
 #include "occurs.c"
 #include "find_key.c"
 
-
 void	test_replace_key() {
 	char	*env[] = {"something=wrong", "this=false", "some=none", NULL};
 	char	**arr = arr_dup((const char **)env);
@@ -63,3 +62,21 @@ void	test_replace_key_two() {
 // 	arr_free(command);
 // 	clean_shell(shell);
 // }
+
+void	test_replace_using_update() {
+	char	*env[] = {"something=wrong", "this=false", "some=none", NULL};
+	char	**arr = arr_dup((const char **)env);
+	update_variable(arr, "this", "correct");
+	char	*expected[] = {"something=wrong", "this=correct", "some=none", NULL};
+	TEST_ASSERT_EQUAL_STRING_ARRAY(expected, arr, 4);
+	arr_free(arr);
+}
+
+void	test_replace_using_update_overlap_key() {
+	char	*env[] = {"something=wrong", "this=false", "some=none", NULL};
+	char	**arr = arr_dup((const char **)env);
+	update_variable(arr, "thia", "correct");
+	char	*expected[] = {"something=wrong", "this=false", "some=none", NULL};
+	TEST_ASSERT_EQUAL_STRING_ARRAY(expected, arr, 4);
+	arr_free(arr);
+}

--- a/test/support/support_tokens.c
+++ b/test/support/support_tokens.c
@@ -13,6 +13,10 @@
 #define TOKENS_H
 #define STRUCT_H
 
+#ifndef WHITESPACE
+# define WHITESPACE " \t\n\r\v\f"
+#endif
+
 typedef struct s_token	t_token;
 
 enum e_arg
@@ -124,7 +128,7 @@ void	mock_convert_split_token_string_array_to_tokens(t_shell *shell)
 	while (shell->token[i].split_pipes)
 	{
 		// split into command and arguments
-		shell->token[i].tmp_arr = split_outside_quotes(shell->token[i].split_pipes, ' ');
+		shell->token[i].tmp_arr = split_outside_quotes(shell->token[i].split_pipes, WHITESPACE);
 		if (!shell->token[i].tmp_arr)
 			return ;
 		len = arr_len((const char **)shell->token[i].tmp_arr);
@@ -180,11 +184,11 @@ t_shell	*support_test_tokens_input(char *line, char **envp)
 	shell = (t_shell *) malloc(sizeof(t_shell));
 	char	*input = ft_strdup(line);
 
-	shell->split_pipes = split_outside_quotes(input, '|');
+	shell->split_pipes = split_outside_quotes(input, "|");
 	free(input);
 
 	// trim beforehand
-	shell->split_tokens = arr_trim(shell->split_pipes, " ");
+	shell->split_tokens = arr_trim(shell->split_pipes, WHITESPACE);
 	arr_free(shell->split_pipes);
 	shell->owned_envp = arr_dup((const char **)envp);
 

--- a/test/utils/test_arr_tools.c
+++ b/test/utils/test_arr_tools.c
@@ -95,3 +95,25 @@ void	test_arr_dup_empty_string() {
 	TEST_ASSERT_EQUAL_STRING("", arr[0]);
 	arr_free(arr);
 }
+
+char	**init_env(const char **envp)
+{
+	char	**env;
+
+	if (!envp)
+		return (NULL);
+	env = append_str_arr(envp, "$?=0");
+	if (!env)
+		return (NULL);
+	return (env);
+}
+
+void	test_arr_init_env() {
+	char	*envp[] = {"PATH=/usr/bin", "HOME=/home", "USER=me", NULL};
+	char	**env = init_env((const char **)envp);
+
+	TEST_ASSERT_NOT_NULL(env);
+	char	*expected[] = {"PATH=/usr/bin", "HOME=/home", "USER=me", "$?=0", NULL};
+	TEST_ASSERT_EQUAL_STRING_ARRAY(expected, env, 5);
+	arr_free(env);
+}

--- a/test/utils/test_arr_tools.c
+++ b/test/utils/test_arr_tools.c
@@ -102,7 +102,7 @@ char	**init_env(const char **envp)
 
 	if (!envp)
 		return (NULL);
-	env = append_str_arr(envp, "$?=0");
+	env = append_str_arr(envp, "?=0");
 	if (!env)
 		return (NULL);
 	return (env);
@@ -113,7 +113,7 @@ void	test_arr_init_env() {
 	char	**env = init_env((const char **)envp);
 
 	TEST_ASSERT_NOT_NULL(env);
-	char	*expected[] = {"PATH=/usr/bin", "HOME=/home", "USER=me", "$?=0", NULL};
+	char	*expected[] = {"PATH=/usr/bin", "HOME=/home", "USER=me", "?=0", NULL};
 	TEST_ASSERT_EQUAL_STRING_ARRAY(expected, env, 5);
 	arr_free(env);
 }


### PR DESCRIPTION
- initialize environment with exit_code
- add ability to use a set with split_outside_quotes (e.g. for handling different kinds of whitespace)
- closes #12
- commented out some code for testing