### PR TITLE
Feature/expand non envars

### DIFF
--- a/src/builtins/cd.c
+++ b/src/builtins/cd.c
@@ -48,8 +48,8 @@ int	builtin_cd(char **cmd_args, char **envp)
 	char	*path;
 	char	*oldpwd;
 
-	path = get_var_val((const char **)envp, "HOME");
-	oldpwd = get_var_val((const char **)envp, "OLDPWD");
+	path = get_env_var((const char **)envp, "HOME");
+	oldpwd = get_env_var((const char **)envp, "OLDPWD");
 	if (!cmd_args[1] && !path)
 		return (dprintf(STDERR_FILENO, "minishell: cd: HOME not set\n"), 1);
 	if (!cmd_args[1] && path)

--- a/src/builtins/pwd.c
+++ b/src/builtins/pwd.c
@@ -9,7 +9,7 @@ int	builtin_pwd(const char **envp)
 	char	*env_pwd;
 
 	tmp = getcwd(NULL, 0);
-	env_pwd = get_var_val(envp, "PWD");
+	env_pwd = get_env_var(envp, "PWD");
 	if (!env_pwd)
 		printf("%s\n", tmp);
 	else

--- a/src/environment/environment.h
+++ b/src/environment/environment.h
@@ -11,6 +11,7 @@ int		find_key_env(const char **arr, const char *s, size_t (*f)(const char *s));
 bool	check_valid_key(const char *s);
 char	**export_var(char **arr, const char *s);
 
-char	*get_var_val(const char **envp, const char *key);
+char	*get_env_var(const char **envp, const char *key);
+char	*expand_var(const char *input, const char **envp);
 
 #endif

--- a/src/environment/find_key.c
+++ b/src/environment/find_key.c
@@ -50,7 +50,7 @@ int	find_key_env(const char **arr, const char *s, size_t (*f)(const char *s))
 // get value of key
 // use index, then trim off key
 // NULL on error or key not found (then caller should not replace)
-char	*get_var_val(const char **arr, const char *key)
+char	*get_env_var(const char **arr, const char *key)
 {
 	int		index;
 	char	*key_eq;
@@ -75,7 +75,7 @@ char	*get_var_val(const char **arr, const char *key)
 	return (NULL);
 }
 
-char	*join_strings_free(int count, ...);
+char	*free_strjoin(int count, ...);
 
 /**
  * @brief replace expandable variable with its value
@@ -85,7 +85,7 @@ char	*join_strings_free(int count, ...);
  * @param envp {"KEY=VALUE", NULL}
  * @return char* VALUEsomething
  */
-char	*expand_in_string(const char *input, const char **envp)
+char	*expand_var(const char *input, const char **envp)
 {
 	size_t	i;
 	char	*tmp;
@@ -96,26 +96,25 @@ char	*expand_in_string(const char *input, const char **envp)
 		return (NULL);
 	if (*input != '$')
 		return (ft_strdup(input));
-	i = get_len_until(&input[1], '$') + 1;
+	i = get_len_until(&input[1], '$') + 2;
 	// fprintf(stderr, "i: %zu\n", i);
 	// for (size_t j = 0; j < i; j++)
 		// fprintf(stderr, "%c", input[j]);
 	// fprintf(stderr, "\n");
-	while (i > 0)
+	while (i > 2 && --i)
 	{
 		tmp = ft_substr(input, 1, i - 1);
 		// fprintf(stderr, "tmp: %s\n", tmp);
-		fprintf(stderr, "input: %s\n", &input[1]);
-		val = get_var_val(envp, tmp);
+		// fprintf(stderr, "input: %s\n", tmp);
+		val = get_env_var(envp, tmp);
 		// fprintf(stderr, "val: %s\n", val);
 		free(tmp);
 		if (val)
 		{
 			remainder = ft_substr(input, i, ft_strlen(input));
-			// fprintf(stderr, "joined: '%s'\n", join_strings_free(2, val, remainder));
-			return (join_strings_free(2, val, remainder));
+			// fprintf(stderr, "joined: '%s'\n", free_strjoin(2, val, remainder));
+			return (free_strjoin(2, val, remainder));
 		}
-		i--;
 	}
 	return (ft_strdup(""));
 }

--- a/src/environment/find_key.c
+++ b/src/environment/find_key.c
@@ -14,6 +14,18 @@ size_t	get_key_len(const char *s)
 	return (-1);
 }
 
+size_t	get_len_until(const char *s, char c)
+{
+	size_t	i;
+
+	i = 0;
+	if (!s)
+		return (0);
+	while (s[i] && s[i] != c)
+		i++;
+	return (i);
+}
+
 int	find_key_env(const char **arr, const char *s, size_t (*f)(const char *s))
 {
 	size_t	i;
@@ -59,6 +71,51 @@ char	*get_var_val(const char **arr, const char *key)
 		if (!val)
 			return (NULL);
 		return (val);
+	}
+	return (NULL);
+}
+
+char	*join_strings_free(int count, ...);
+
+/**
+ * @brief replace expandable variable with its value
+ * @details check for valid key & null before calling, do not hand in without single $ at beginning, key does not have to exist, only single variable will be expanded
+ *
+ * @param input $KEYsomething
+ * @param envp {"KEY=VALUE", NULL}
+ * @return char* VALUEsomething
+ */
+char	*expand_in_string(const char *input, const char **envp)
+{
+	size_t	i;
+	char	*tmp;
+	char	*remainder;
+	char	*val;
+
+	if (!input || !envp || !*envp)
+		return (NULL);
+	if (*input != '$')
+		return (ft_strdup(input));
+	i = get_len_until(&input[1], '$') + 1;
+	// fprintf(stderr, "i: %zu\n", i);
+	// for (size_t j = 0; j < i; j++)
+		// fprintf(stderr, "%c", input[j]);
+	// fprintf(stderr, "\n");
+	while (i > 0)
+	{
+		tmp = ft_substr(input, 1, i - 1);
+		// fprintf(stderr, "tmp: %s\n", tmp);
+		fprintf(stderr, "input: %s\n", &input[1]);
+		val = get_var_val(envp, tmp);
+		// fprintf(stderr, "val: %s\n", val);
+		free(tmp);
+		if (val)
+		{
+			remainder = ft_substr(input, i, ft_strlen(input));
+			// fprintf(stderr, "joined: '%s'\n", join_strings_free(2, val, remainder));
+			return (join_strings_free(2, val, remainder));
+		}
+		i--;
 	}
 	return (ft_strdup(""));
 }

--- a/src/expander/expand_variables.c
+++ b/src/expander/expand_variables.c
@@ -1,108 +1,97 @@
-#include "libft.h"
-#include <stdbool.h>
+// #include "libft.h"
+// #include <stdbool.h>
 
-typedef struct s_expander
-{
-	size_t	i;
-	char	*ret;
-	char	*key;
-	size_t	start;
-	char	*val;
-	char	*tmp;
-	int		singlequote;
-	char	*remainder_line;
-	char	*line;
-}	t_expander;
+// typedef struct s_expander
+// {
+// 	size_t	i;
+// 	char	*ret;
+// 	char	*key;
+// 	size_t	start;
+// 	char	*val;
+// 	char	*tmp;
+// 	int		singlequote;
+// 	char	*remainder_line;
+// 	char	*line;
+// }	t_expander;
 
+// char	*expand_variables(const char *input, const char **envp);
 
-static bool	is_valid_key(int c)
-{
-	if (ft_isalnum(c) || c == '_')
-		return (true);
-	return (false);
-}
+// static char *replacer(t_expander *x, const char **envp)
+// {
+// 	if (!x->ret)
+// 		return (NULL);
+// 	if (x->i <= ft_strlen(x->line))
+// 	{
+// 		x->remainder_line = ft_strdup(&x->line[x->i]);
+// 		free(x->line);
+// 		if (!x->remainder_line)
+// 			return (x->ret);
+// 		// printf("remainder: %s\n", x->remainder_line);
+// 		x->tmp = ft_strjoin(x->ret, x->remainder_line);
+// 		free(x->remainder_line);
+// 		free(x->ret);
+// 		x->ret = expand_variables(x->tmp, envp);
+// 		free(x->tmp);
+// 	}
+// 	return (x->ret);
+// }
 
-char	*get_var_val(const char **arr, const char *key);
-char	*expand_variables(const char *input, const char **envp);
+// static char	*insert_value(t_expander *x, const char **envp)
+// {
+// 	x->key = ft_substr(x->line, x->start, x->i - x->start);
+// 	if (!x->key)
+// 		return (NULL);
+// 	x->val = get_env_var(envp, x->key);
+// 	free(x->key);
+// 	if (!x->val)
+// 		return (NULL);
+// 	x->tmp = ft_substr(x->line, 0, x->start - 1);
+// 	if (!x->tmp)
+// 		return (free(x->val), NULL);
+// 	x->ret = ft_strjoin(x->tmp, x->val);
+// 	free(x->tmp);
+// 	free(x->val);
+// 	return (x->ret);
+// }
 
-static char *replacer(t_expander *x, const char **envp)
-{
-	if (!x->ret)
-		return (NULL);
-	if (x->i <= ft_strlen(x->line))
-	{
-		x->remainder_line = ft_strdup(&x->line[x->i]);
-		free(x->line);
-		if (!x->remainder_line)
-			return (x->ret);
-		// printf("remainder: %s\n", x->remainder_line);
-		x->tmp = ft_strjoin(x->ret, x->remainder_line);
-		free(x->remainder_line);
-		free(x->ret);
-		x->ret = expand_variables(x->tmp, envp);
-		free(x->tmp);
-	}
-	return (x->ret);
-}
+// static char	*check_line(t_expander *x, const char **envp)
+// {
+// 	while (x->line && x->line[x->i])
+// 	{
+// 		if (x->line[x->i] == '\'' && x->singlequote == 0)
+// 			x->singlequote = x->line[x->i];
+// 		else if (x->line[x->i] == '\'' && x->singlequote == x->line[x->i])
+// 			x->singlequote = 0;
+// 		else if (x->line[x->i] && x->line[x->i + 1] && x->line[x->i] == '$'
+// 			&& x->singlequote == 0 && (is_valid_key(x->line[x->i + 1]) || x->line[x->i + 1] == '?'))
+// 		{
+// 			x->i++;
+// 			x->start = x->i;
+// 			if (x->line[x->i] != '?')
+// 				while (x->line[x->i] && is_valid_key(x->line[x->i]))
+// 					x->i++;
+// 			else
+// 				x->i++;
+// 			if (x->start == x->i)
+// 				continue;
+// 			if (!insert_value(x, envp))
+// 				return (NULL);
+// 			return (replacer(x, envp));
+// 		}
+// 		if (x->line[x->i] == '$' && x->singlequote == 0 && x->line[x->i + 1])
+// 			x->line[x->i] = ' ';
+// 		x->i++;
+// 	}
+// 	return (x->line);
+// }
 
-static char	*insert_value(t_expander *x, const char **envp)
-{
-	x->key = ft_substr(x->line, x->start, x->i - x->start);
-	if (!x->key)
-		return (NULL);
-	x->val = get_var_val(envp, x->key);
-	free(x->key);
-	if (!x->val)
-		return (NULL);
-	x->tmp = ft_substr(x->line, 0, x->start - 1);
-	if (!x->tmp)
-		return (free(x->val), NULL);
-	x->ret = ft_strjoin(x->tmp, x->val);
-	free(x->tmp);
-	free(x->val);
-	return (x->ret);
-}
+// char	*expand_variables_old(const char *input, const char **envp)
+// {
+// 	t_expander	x;
 
-static char	*check_line(t_expander *x, const char **envp)
-{
-	while (x->line && x->line[x->i])
-	{
-		if (x->line[x->i] == '\'' && x->singlequote == 0)
-			x->singlequote = x->line[x->i];
-		else if (x->line[x->i] == '\'' && x->singlequote == x->line[x->i])
-			x->singlequote = 0;
-		else if (x->line[x->i] && x->line[x->i + 1] && x->line[x->i] == '$'
-			&& x->singlequote == 0 && (is_valid_key(x->line[x->i + 1]) || x->line[x->i + 1] == '?'))
-		{
-			x->i++;
-			x->start = x->i;
-			if (x->line[x->i] != '?')
-				while (x->line[x->i] && is_valid_key(x->line[x->i]))
-					x->i++;
-			else
-				x->i++;
-			if (x->start == x->i)
-				continue;
-			if (!insert_value(x, envp))
-				return (NULL);
-			return (replacer(x, envp));
-		}
-		if (x->line[x->i] == '$' && x->singlequote == 0 && x->line[x->i + 1])
-			x->line[x->i] = ' ';
-		x->i++;
-	}
-	return (x->line);
-}
-
-// @follow-up handle in parentheses
-/* @todo correct behaviour with quotes (pass in from top, same in recursion (shared state))*/
-char	*expand_variables_old(const char *input, const char **envp)
-{
-	t_expander	x;
-
-	x.i = 0;
-	x.singlequote = 0;
-	x.line = ft_strdup(input);
-	return (check_line(&x, envp));
-}
+// 	x.i = 0;
+// 	x.singlequote = 0;
+// 	x.line = ft_strdup(input);
+// 	return (check_line(&x, envp));
+// }
 

--- a/src/expander/expand_variables.c
+++ b/src/expander/expand_variables.c
@@ -96,7 +96,7 @@ static char	*check_line(t_expander *x, const char **envp)
 
 // @follow-up handle in parentheses
 /* @todo correct behaviour with quotes (pass in from top, same in recursion (shared state))*/
-char	*expand_variables(const char *input, const char **envp)
+char	*expand_variables_old(const char *input, const char **envp)
 {
 	t_expander	x;
 
@@ -105,3 +105,4 @@ char	*expand_variables(const char *input, const char **envp)
 	x.line = ft_strdup(input);
 	return (check_line(&x, envp));
 }
+

--- a/src/expander/expander.c
+++ b/src/expander/expander.c
@@ -1,0 +1,148 @@
+#include "libft.h"
+#include <stdbool.h>
+#include <stdio.h>
+#include <sys/param.h>
+#include "environment.h"
+
+char	*expand_variables(const char *input, const char **envp);
+char	*expand_in_string(const char *input, const char **envp);
+char	*guard_expander(const char *input, const char **envp)
+{
+	if (!input || !envp || !*envp || !*input)
+		return (NULL);
+	return (expand_variables(input, envp));
+}
+
+char	*join_strings_free(int count, ...);
+
+char	*expand_variables(const char *input, const char **envp)
+{
+	size_t	i;
+	size_t	j;
+	size_t	len;
+	char	*expanded;
+	char	*key;
+	char	*val;
+	char	*tmp;
+
+	i = 0;
+	len = ft_strlen(input);
+	expanded = ft_strdup(input);
+	if (!expanded)
+		return (NULL);
+	while (i < len)
+	{
+		while (expanded[i] == '$' && expanded[i + 1] == '$')
+			i++;
+		if (expanded[i] == '$')
+		{
+			j = i + 1;
+			while (j < len && ft_isalnum(expanded[j]))
+				j++;
+			key = ft_substr(expanded, i + 1, j - i - 1);
+			if (!key)
+				return (free(expanded), NULL);
+			val = expand_in_string(key, envp);
+			free(key);
+			if (!val)
+				return (free(expanded), NULL);
+			tmp = ft_strjoin(expanded, val);
+			free(val);
+			free(expanded);
+			if (!tmp)
+				return (NULL);
+			expanded = tmp;
+			len = ft_strlen(expanded);
+		}
+		i++;
+	}
+	return (expanded);
+}
+
+
+
+// iterate over to find key
+
+// if key found, replace range of $key with value
+
+// if key contains $key, expand only its string to value
+
+// else iterate over to find next key
+
+// if there are $key$key_two, expand each key separately
+
+// if the expansion of $key results in key, do not expand
+
+// if the expansion of $key results in $key, expand
+
+// an input string like $invalid$key$keytwo will result in valuevaluetwo (invalid is replaced with empty)
+// $$key$keytwo will result in $valuevaluetwo
+char	*expander(const char *input_expand, const char **envp)
+{
+	char	*expanded;
+	char	*tmp2;
+	char	*after_expansion;
+	char	*tmp;
+	char	*to_expand;
+	char	*before_expansion;
+	size_t	i;
+	size_t	tmp_len;
+	size_t	end;
+
+	if (!input_expand || !envp || !*envp)
+		return (NULL);
+
+	char	*input = ft_strdup(input_expand);
+	if (!input)
+		return (NULL);
+	if (ft_strlen(input) == 1)
+		return (input);
+	// source string with $$USER
+	i = 0;// @todo implement quotes
+	while (input[i])
+	{
+		while (input[i] && input[i] == '$' && input[i + 1] == '$')
+			i++;
+		if (input[i] && input[i] == '$')// if variable denotation
+		{
+			end = i + 1;
+			while (input[end] && (ft_isalnum(input[end]) || input[end] == '_'))
+				end++;
+			fprintf(stderr, "%s\n", &input[end]);
+			to_expand = ft_substr(input, i, end - i);
+			printf("to_expand: %s\n", to_expand);
+			if (!to_expand)
+				return (NULL);
+			expanded = expand_in_string(to_expand, envp);
+			printf("expanded: %s\n", expanded);
+			if (!expanded)
+				return (free(to_expand), NULL);
+			before_expansion = ft_substr(input, 0, i);
+			after_expansion = ft_strdup(&input[end]);
+			fprintf(stderr, "before_expansion: %s\n", before_expansion);
+			fprintf(stderr, "expanded: %s\n", expanded);
+			tmp_len = ft_strlen(before_expansion) + ft_strlen(expanded) - 1;
+			free(to_expand);
+			if (tmp_len <= 0)
+				return (free(expanded), NULL);
+			tmp = ft_strjoin(before_expansion, expanded);
+			fprintf(stderr, "tmp: %s\n", tmp);
+			free(expanded);
+			free(before_expansion);
+			fprintf(stderr, "after_expansion: %s\n", after_expansion);
+			tmp2 = ft_strjoin(tmp, after_expansion);
+			free(after_expansion);
+			if (!tmp2)
+				return (free(input), tmp);
+			free(tmp);
+			fprintf(stderr, "tmp2: %s\n", tmp2);
+			free(input);
+			input = tmp2;
+			fprintf(stderr, "internal_input: %s\n", input);
+			i = tmp_len - 1;
+		}
+		else
+			i++;
+	}
+	return (input);
+}

--- a/src/expander/expander.c
+++ b/src/expander/expander.c
@@ -1,86 +1,20 @@
+#include "environment.h"
 #include "libft.h"
 #include <stdbool.h>
 #include <stdio.h>
 #include <sys/param.h>
-#include "environment.h"
+#include "utils.h"
 
-char	*expand_variables(const char *input, const char **envp);
-char	*expand_in_string(const char *input, const char **envp);
-char	*guard_expander(const char *input, const char **envp)
+static bool	is_valid_key(int c)
 {
-	if (!input || !envp || !*envp || !*input)
-		return (NULL);
-	return (expand_variables(input, envp));
+	if (ft_isalnum(c) || c == '_')
+		return (true);
+	return (false);
 }
 
-char	*join_strings_free(int count, ...);
-
-char	*expand_variables(const char *input, const char **envp)
-{
-	size_t	i;
-	size_t	j;
-	size_t	len;
-	char	*expanded;
-	char	*key;
-	char	*val;
-	char	*tmp;
-
-	i = 0;
-	len = ft_strlen(input);
-	expanded = ft_strdup(input);
-	if (!expanded)
-		return (NULL);
-	while (i < len)
-	{
-		while (expanded[i] == '$' && expanded[i + 1] == '$')
-			i++;
-		if (expanded[i] == '$')
-		{
-			j = i + 1;
-			while (j < len && ft_isalnum(expanded[j]))
-				j++;
-			key = ft_substr(expanded, i + 1, j - i - 1);
-			if (!key)
-				return (free(expanded), NULL);
-			val = expand_in_string(key, envp);
-			free(key);
-			if (!val)
-				return (free(expanded), NULL);
-			tmp = ft_strjoin(expanded, val);
-			free(val);
-			free(expanded);
-			if (!tmp)
-				return (NULL);
-			expanded = tmp;
-			len = ft_strlen(expanded);
-		}
-		i++;
-	}
-	return (expanded);
-}
-
-
-
-// iterate over to find key
-
-// if key found, replace range of $key with value
-
-// if key contains $key, expand only its string to value
-
-// else iterate over to find next key
-
-// if there are $key$key_two, expand each key separately
-
-// if the expansion of $key results in key, do not expand
-
-// if the expansion of $key results in $key, expand
-
-// an input string like $invalid$key$keytwo will result in valuevaluetwo (invalid is replaced with empty)
-// $$key$keytwo will result in $valuevaluetwo
-char	*expander(const char *input_expand, const char **envp)
+static char	*expand_variables(char *input, const char **envp)
 {
 	char	*expanded;
-	char	*tmp2;
 	char	*after_expansion;
 	char	*tmp;
 	char	*to_expand;
@@ -88,61 +22,80 @@ char	*expander(const char *input_expand, const char **envp)
 	size_t	i;
 	size_t	tmp_len;
 	size_t	end;
+	int		singlequote;
 
-	if (!input_expand || !envp || !*envp)
-		return (NULL);
-
-	char	*input = ft_strdup(input_expand);
 	if (!input)
 		return (NULL);
-	if (ft_strlen(input) == 1)
-		return (input);
-	// source string with $$USER
-	i = 0;// @todo implement quotes
-	while (input[i])
+	i = 0;
+	singlequote = 0;
+	while (input && input[i] && input[i + 1])
 	{
-		while (input[i] && input[i] == '$' && input[i + 1] == '$')
+		while (input[i] && input[i] == '$' && input[i + 1] && input[i + 1] == '$')
 			i++;
-		if (input[i] && input[i] == '$')// if variable denotation
+		if (input[i] == '\'' && singlequote == 0)
+			singlequote = input[i];
+		else if (input[i] == '\'' && singlequote == input[i])
+			singlequote = 0;
+		if (input[i] && input[i] == '$' && input[i + 1] && singlequote == 0)
 		{
 			end = i + 1;
-			while (input[end] && (ft_isalnum(input[end]) || input[end] == '_'))
+			// fprintf(stderr, "input: %s\n", &input[end]);
+			if (input[end] != '?')
+				while (input[end] && is_valid_key(input[end]))
+					end++;
+			else
 				end++;
-			fprintf(stderr, "%s\n", &input[end]);
 			to_expand = ft_substr(input, i, end - i);
-			printf("to_expand: %s\n", to_expand);
+			// printf("to_expand: '%s'\n", to_expand);
 			if (!to_expand)
 				return (NULL);
-			expanded = expand_in_string(to_expand, envp);
-			printf("expanded: %s\n", expanded);
+			expanded = expand_var(to_expand, envp);
+			// printf("expanded: '%s'\n", expanded);
 			if (!expanded)
 				return (free(to_expand), NULL);
 			before_expansion = ft_substr(input, 0, i);
 			after_expansion = ft_strdup(&input[end]);
-			fprintf(stderr, "before_expansion: %s\n", before_expansion);
-			fprintf(stderr, "expanded: %s\n", expanded);
+			// fprintf(stderr, "before_expansion: %s\n", before_expansion);
+			// fprintf(stderr, "expanded: %s\n", expanded);
 			tmp_len = ft_strlen(before_expansion) + ft_strlen(expanded) - 1;
 			free(to_expand);
-			if (tmp_len <= 0)
-				return (free(expanded), NULL);
-			tmp = ft_strjoin(before_expansion, expanded);
-			fprintf(stderr, "tmp: %s\n", tmp);
-			free(expanded);
-			free(before_expansion);
-			fprintf(stderr, "after_expansion: %s\n", after_expansion);
-			tmp2 = ft_strjoin(tmp, after_expansion);
-			free(after_expansion);
-			if (!tmp2)
-				return (free(input), tmp);
-			free(tmp);
-			fprintf(stderr, "tmp2: %s\n", tmp2);
+			tmp = free_strjoin(2, before_expansion, expanded);
+			// fprintf(stderr, "tmp: %s\n", tmp);
+			// fprintf(stderr, "after_expansion: %s\n", after_expansion);
 			free(input);
-			input = tmp2;
-			fprintf(stderr, "internal_input: %s\n", input);
-			i = tmp_len - 1;
+			input = ft_strjoin(tmp, after_expansion);
+			free(after_expansion);
+			if (!input)
+				return (tmp);
+			free(tmp);
+			i = tmp_len + 1;
 		}
 		else
 			i++;
 	}
 	return (input);
+}
+
+/**
+ * @brief iterate over to find key
+ * @details if key found, replace range of $key with value
+ * \details if key contains $key, expand only its string to value
+ * \details else iterate over to find next key
+ * \details if there are $key$key_two, expand each key separately
+ * \details if the expansion of $key results in key, do not expand
+ * \details if the expansion of $key results in $key, expand
+ * \details $invalid$key$keytwo -> valuevaluetwo (invalid empty)
+ * @example input: $$USER -> $username
+ * @param input_expander
+ * @param envp
+ * @return char*
+ */
+char	*expander(const char *input_expander, const char **envp)
+{
+	char	*restrict input;
+
+	if (!input_expander || !envp || !*envp || !*input_expander)
+		return (NULL);
+	input = ft_strdup(input_expander);
+	return (expand_variables(input, envp));
 }

--- a/src/expander/expander.h
+++ b/src/expander/expander.h
@@ -1,6 +1,6 @@
 #ifndef EXPANDER_H
 # define EXPANDER_H
 
-char	*expand_variables(const char *input, const char **envp);
+char	*expander(const char *input_expander, const char **envp);
 
 #endif

--- a/src/expander/join_strings.c
+++ b/src/expander/join_strings.c
@@ -1,0 +1,59 @@
+#include "libft.h"
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+void	free_n(int n, ...);
+
+/**
+ * @brief requires heap-allocation
+ *
+ * @param count number of strings to join
+ * @param ... strings to join
+ * @return char* joined string
+ */
+char	*join_strings_free(int count, ...)
+{
+	va_list	args;
+	char	*ret;
+	char	*tmp;
+	char	*arg;
+	int		i;
+
+	va_start(args, count);
+	ret = va_arg(args, char *);
+	i = 1;
+	while (i < count)
+	{
+		arg = va_arg(args, char *);
+		if (!ret || !arg)
+		{
+			free_n(2, ret, arg);
+			while (++i < count)
+				free(va_arg(args, char *));
+			return (va_end(args), NULL);
+		}
+		tmp = ft_strjoin(ret, arg);
+		free_n(2, ret, arg);
+		ret = tmp;
+		i++;
+	}
+	return (va_end(args), ret);
+}
+
+void	free_n(int n, ...)
+{
+	va_list	args;
+	int		i;
+
+	va_start(args, n);
+	i = 0;
+	while (i < n)
+	{
+		free(va_arg(args, void *));
+		i++;
+	}
+	va_end(args);
+}
+

--- a/src/init.c
+++ b/src/init.c
@@ -44,10 +44,10 @@ void	update_exit_status(t_shell *shell, int status)
 	if (!new_status)
 		return ;
 	shell->tmp_arr = export_var(shell->owned_envp, new_status);
+	free(new_status);
 	if (!shell->tmp_arr)
 	{
 		free(status_str);
-		free(new_status);
 		return ;
 	}
 }

--- a/src/tokenizer/build_tokens.c
+++ b/src/tokenizer/build_tokens.c
@@ -1,4 +1,5 @@
 #include <stddef.h>
+#include <sys/param.h>
 #include "libft.h"
 #include "tokens.h"
 #include "utils.h"
@@ -68,10 +69,12 @@ void	builtin_info(t_token *token)
 		token->builtin_info = NOT_BUILTIN;
 }
 
-// @audit-info mod split_quotes to take a function pointer (for whitespace that can be space or tab)
+char	*expander(const char *input, const char **envp);
+
 // take the token with command string and split it into command and arguments
 // if we find any pipes
 char	*expand_variables(const char *input, const char **envp);
+char	*expand_variables_old(const char *input, const char **envp);
 void	convert_split_token_string_array_to_tokens(t_shell *shell)
 {
 	size_t	i;
@@ -112,24 +115,19 @@ void	convert_split_token_string_array_to_tokens(t_shell *shell)
 				shell->token[i].cmd_args[ii].quote = DOUBLE;
 			if (str_cchr(shell->token[i].cmd_args[ii].elem, '\''))
 				shell->token[i].cmd_args[ii].quote = SINGLE;
-			while (shell->token[i].builtin_info != ENV &&
-					shell->token[i].builtin_info != EXPORT &&
-					shell->token[i].builtin_info != UNSET &&
-				str_cchr(shell->token[i].cmd_args[ii].elem, '$'))
+			tmp = expander(shell->token[i].cmd_args[ii].elem, (const char **)shell->owned_envp);
+			fprintf(stderr, "tmp in convert: %s\n", tmp);
+			if (!tmp)
+				return ;
+			if (ft_strncmp(tmp, shell->token[i].cmd_args[ii].elem, MAX(ft_strlen(tmp), ft_strlen(shell->token[i].cmd_args[ii].elem))== 0))
 			{
-				tmp = expand_variables(shell->token[i].cmd_args[ii].elem, (const char **)shell->owned_envp);
-				if (!tmp)
-					return ;
-				if (ft_strncmp(tmp, shell->token[i].cmd_args[ii].elem, ft_strlen(tmp)) == 0)
-				{
-					// printf("recursive expansion is the same as the original, freeing\n");
-					// printf("reex: %s\n", shell->token[i].cmd_args[ii].elem);
-					free(tmp);
-					break ;
-				}
-				free(shell->token[i].cmd_args[ii].elem);
-				shell->token[i].cmd_args[ii].elem = tmp;
+				// printf("recursive expansion is the same as the original, freeing\n");
+				// printf("reex: %s\n", shell->token[i].cmd_args[ii].elem);
+				free(tmp);
+				break ;
 			}
+			free(shell->token[i].cmd_args[ii].elem);
+			shell->token[i].cmd_args[ii].elem = tmp;
 			int quote = 0;
 			if (shell->token[i].cmd_args[ii].quote != NONE)
 			{

--- a/src/tokenizer/build_tokens.c
+++ b/src/tokenizer/build_tokens.c
@@ -73,8 +73,6 @@ char	*expander(const char *input, const char **envp);
 
 // take the token with command string and split it into command and arguments
 // if we find any pipes
-char	*expand_variables(const char *input, const char **envp);
-char	*expand_variables_old(const char *input, const char **envp);
 void	convert_split_token_string_array_to_tokens(t_shell *shell)
 {
 	size_t	i;
@@ -116,7 +114,7 @@ void	convert_split_token_string_array_to_tokens(t_shell *shell)
 			if (str_cchr(shell->token[i].cmd_args[ii].elem, '\''))
 				shell->token[i].cmd_args[ii].quote = SINGLE;
 			tmp = expander(shell->token[i].cmd_args[ii].elem, (const char **)shell->owned_envp);
-			fprintf(stderr, "tmp in convert: %s\n", tmp);
+			// fprintf(stderr, "tmp in convert: %s\n", tmp);
 			if (!tmp)
 				return ;
 			if (ft_strncmp(tmp, shell->token[i].cmd_args[ii].elem, MAX(ft_strlen(tmp), ft_strlen(shell->token[i].cmd_args[ii].elem))== 0))

--- a/src/utils/arr_utils.c
+++ b/src/utils/arr_utils.c
@@ -9,7 +9,7 @@ char	**append_str_arr(const char **arr, const char *s)
 	size_t	i;
 	char	**ret;
 
-	if (!s || !*s)
+	if (!s)
 		return (NULL);
 	len = arr_len((const char **)arr);
 	ret = (char **) ft_calloc(len + 2, sizeof(char *));

--- a/src/utils/fn_free.c
+++ b/src/utils/fn_free.c
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+
+void	*fn_apply_free(void	*a, void *b, void *(*f)(void *, void *))
+{
+	void	*ptr;
+
+	ptr = f(a, b);
+	free(a);
+	free(b);
+	return (ptr);
+}

--- a/src/utils/free_strjoin.c
+++ b/src/utils/free_strjoin.c
@@ -4,7 +4,20 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-void	free_n(int n, ...);
+void	free_n(int n, ...)
+{
+	va_list	args;
+	int		i;
+
+	va_start(args, n);
+	i = 0;
+	while (i < n)
+	{
+		free(va_arg(args, void *));
+		i++;
+	}
+	va_end(args);
+}
 
 /**
  * @brief requires heap-allocation
@@ -13,7 +26,7 @@ void	free_n(int n, ...);
  * @param ... strings to join
  * @return char* joined string
  */
-char	*join_strings_free(int count, ...)
+char	*free_strjoin(int count, ...)
 {
 	va_list	args;
 	char	*ret;
@@ -41,19 +54,3 @@ char	*join_strings_free(int count, ...)
 	}
 	return (va_end(args), ret);
 }
-
-void	free_n(int n, ...)
-{
-	va_list	args;
-	int		i;
-
-	va_start(args, n);
-	i = 0;
-	while (i < n)
-	{
-		free(va_arg(args, void *));
-		i++;
-	}
-	va_end(args);
-}
-

--- a/src/utils/str_utils.c
+++ b/src/utils/str_utils.c
@@ -8,3 +8,16 @@ char	*free_first_join(char *s1, const char *s2)
 	free(s1);
 	return (joined);
 }
+
+/**
+ * @brief requires both strings to be heap allocated
+ */
+char	*free_both_join(char *s1, char *s2)
+{
+	char	*joined;
+
+	joined = ft_strjoin((const char *)s1, (const char *)s2);
+	free(s1);
+	free(s2);
+	return (joined);
+}

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -12,6 +12,9 @@ char	**arr_trim(char **arr, char const *set);
 
 void	update_variable(char **envp, const char *key, const char *value);
 char	*free_first_join(char *s1, const char *s2);
+char	*free_strjoin(int count, ...);
+void	free_n(int n, ...);
+
 # include <stddef.h>
 int		arr_ncmp(const char **arr1, const char **arr2, size_t n);
 

--- a/test/env/test_export_var.c
+++ b/test/env/test_export_var.c
@@ -5,6 +5,7 @@
 #include "occurs.c"
 #include "find_key.c"
 #include "str_utils.c"
+#include "join_strings.c"
 
 void	test_replace_key() {
 	char	*env[] = {"something=wrong", "this=false", "some=none", NULL};

--- a/test/env/test_export_var.c
+++ b/test/env/test_export_var.c
@@ -5,7 +5,7 @@
 #include "occurs.c"
 #include "find_key.c"
 #include "str_utils.c"
-#include "join_strings.c"
+#include "free_strjoin.c"
 
 void	test_replace_key() {
 	char	*env[] = {"something=wrong", "this=false", "some=none", NULL};

--- a/test/env/test_key.c
+++ b/test/env/test_key.c
@@ -5,6 +5,8 @@
 
 #include "print_arr_sep.c"
 
+#include "join_strings.c"
+
 void	test_get_key_len() {
 	char	*s = "KEY=val";
 	TEST_ASSERT_EQUAL(3, get_key_len(s));
@@ -38,5 +40,18 @@ void	test_find_key_error() {
 	TEST_ASSERT_EQUAL(-1, index);
 }
 
+void	test_get_len_until() {
+	char	*s = "hello=world";
+	TEST_ASSERT_EQUAL(5, get_len_until(s, '='));
 
+	char	*s2 = "$key$";
+	TEST_ASSERT_EQUAL(0, get_len_until(s2, '$'));
+	TEST_ASSERT_EQUAL(3, get_len_until(&s2[1], '$'));
 
+	// int i = 1;
+	// while (s2[i] && i <= 3)
+	// {
+	// 	printf("%c\n", s2[i]);
+	// 	i++;
+	// }
+}

--- a/test/env/test_key.c
+++ b/test/env/test_key.c
@@ -5,7 +5,7 @@
 
 #include "print_arr_sep.c"
 
-#include "join_strings.c"
+#include "free_strjoin.c"
 
 void	test_get_key_len() {
 	char	*s = "KEY=val";

--- a/test/env/test_read_var.c
+++ b/test/env/test_read_var.c
@@ -11,13 +11,13 @@
 #include "export.c"
 #include "check_key.c"
 #include "env.c"
-#include "join_strings.c"
+#include "free_strjoin.c"
 #include "utils.h"
 
 void	test_read_returns_correct() {
 	char	*env[] = {"not=looking", "maybe=?looking", "key=forsure", "notmine=(null)", NULL};
 	char	**expected = arr_dup((const char **)env);
-	char	*ret = get_var_val((const char **)expected, "key");
+	char	*ret = get_env_var((const char **)expected, "key");
 	TEST_ASSERT_EQUAL_STRING("forsure", ret);
 	arr_free(expected);
 	free(ret);
@@ -26,59 +26,59 @@ void	test_read_returns_correct() {
 void	test_read_returns_correct_two() {
 	char	*env[] = {"not=looking", "maybe=?looking", "key=forsure", "notmine=(null)", NULL};
 	char	**expected = arr_dup((const char **)env);
-	char	*ret = expand_in_string("ke", (const char **)expected);
+	char	*ret = expand_var("ke", (const char **)expected);
 	TEST_ASSERT_EQUAL_STRING("ke", ret);
 	free(ret);
-	ret = expand_in_string("$ke", (const char **)expected);
+	ret = expand_var("$ke", (const char **)expected);
 	TEST_ASSERT_EQUAL_STRING("", ret);
 	free(ret);
-	ret = expand_in_string("$key", (const char **)expected);
+	ret = expand_var("$key", (const char **)expected);
 	TEST_ASSERT_EQUAL_STRING("forsure", ret);
 	arr_free(expected);
 	free(ret);
 }
 
-void	test_expand_in_string() {
+void	test_expand_var() {
 	char	*env[] = {"not=looking", "maybe=?looking", "key=forsure", "notmine=(null)", NULL};
-	char	*ret = expand_in_string("$keylong", (const char **)env);
+	char	*ret = expand_var("$keylong", (const char **)env);
 	TEST_ASSERT_EQUAL_STRING("forsurelong", ret);
 
 	free(ret);
 }
 
-void	test_expand_in_string_dollarsign() {
+void	test_expand_var_dollarsign() {
 	char	*env[] = {"not=looking", "maybe=?looking", "key=forsure", "notmine=(null)", NULL};
-	char	*ret = expand_in_string("$keyl$ong", (const char **)env);
+	char	*ret = expand_var("$keyl$ong", (const char **)env);
 	TEST_ASSERT_EQUAL_STRING("forsurel$ong", ret);
 
 	free(ret);
 }
 
-void	test_expand_in_string_prefix_dollarsign() {
+void	test_expand_var_prefix_dollarsign() {
 	char	*env[] = {"not=looking", "maybe=?looking", "key=forsure", "notmine=(null)", NULL};
-	char	*ret = expand_in_string("$keylong", (const char **)env);
+	char	*ret = expand_var("$keylong", (const char **)env);
 	TEST_ASSERT_EQUAL_STRING("forsurelong", ret);
 
 	free(ret);
 }
 
-void	test_expand_in_string_prefix_no_match() {
+void	test_expand_var_prefix_no_match() {
 	char	*env[] = {"not=looking", "maybe=?looking", "key=forsure", "notmine=(null)", NULL};
-	char	*ret = expand_in_string("$ke", (const char **)env);
+	char	*ret = expand_var("$ke", (const char **)env);
 	TEST_ASSERT_EQUAL_STRING("", ret);
 	free(ret);
 }
 
-void	test_expand_in_string_prefix_dollarsign_null() {
+void	test_expand_var_prefix_dollarsign_null() {
 	char	*env[] = {"not=looking", "maybe=?looking", "key=forsure", "notmine=(null)", NULL};
-	char	*ret = expand_in_string("$key$", (const char **)env);
+	char	*ret = expand_var("$key$", (const char **)env);
 	TEST_ASSERT_EQUAL_STRING("forsure$", ret);
 	free(ret);
 }
 
-// void	test_expand_in_string_prefix_multiple() {
+// void	test_expand_var_prefix_multiple() {
 // 	char	*env[] = {"not=looking", "maybe=?looking", "key=forsure", "notmine=(null)", NULL};
-// 	char	*ret = expand_in_string("$$key$notmine", (const char **)env);
+// 	char	*ret = expand_var("$$key$notmine", (const char **)env);
 // 	TEST_ASSERT_EQUAL_STRING("$$forsure$notmine", ret);
 // 	// trim off until non-expanded key
 // 	free(ret);

--- a/test/env/test_read_var.c
+++ b/test/env/test_read_var.c
@@ -1,4 +1,3 @@
-#include "export.c"
 #include "environment.h"
 #include "find_key.c"
 #include "unity.h"
@@ -9,6 +8,11 @@
 #include "print_arr_sep.c"
 #include "export_var.c"
 #include "str_utils.c"
+#include "export.c"
+#include "check_key.c"
+#include "env.c"
+#include "join_strings.c"
+#include "utils.h"
 
 void	test_read_returns_correct() {
 	char	*env[] = {"not=looking", "maybe=?looking", "key=forsure", "notmine=(null)", NULL};
@@ -18,3 +22,64 @@ void	test_read_returns_correct() {
 	arr_free(expected);
 	free(ret);
 }
+
+void	test_read_returns_correct_two() {
+	char	*env[] = {"not=looking", "maybe=?looking", "key=forsure", "notmine=(null)", NULL};
+	char	**expected = arr_dup((const char **)env);
+	char	*ret = expand_in_string("ke", (const char **)expected);
+	TEST_ASSERT_EQUAL_STRING("ke", ret);
+	free(ret);
+	ret = expand_in_string("$ke", (const char **)expected);
+	TEST_ASSERT_EQUAL_STRING("", ret);
+	free(ret);
+	ret = expand_in_string("$key", (const char **)expected);
+	TEST_ASSERT_EQUAL_STRING("forsure", ret);
+	arr_free(expected);
+	free(ret);
+}
+
+void	test_expand_in_string() {
+	char	*env[] = {"not=looking", "maybe=?looking", "key=forsure", "notmine=(null)", NULL};
+	char	*ret = expand_in_string("$keylong", (const char **)env);
+	TEST_ASSERT_EQUAL_STRING("forsurelong", ret);
+
+	free(ret);
+}
+
+void	test_expand_in_string_dollarsign() {
+	char	*env[] = {"not=looking", "maybe=?looking", "key=forsure", "notmine=(null)", NULL};
+	char	*ret = expand_in_string("$keyl$ong", (const char **)env);
+	TEST_ASSERT_EQUAL_STRING("forsurel$ong", ret);
+
+	free(ret);
+}
+
+void	test_expand_in_string_prefix_dollarsign() {
+	char	*env[] = {"not=looking", "maybe=?looking", "key=forsure", "notmine=(null)", NULL};
+	char	*ret = expand_in_string("$keylong", (const char **)env);
+	TEST_ASSERT_EQUAL_STRING("forsurelong", ret);
+
+	free(ret);
+}
+
+void	test_expand_in_string_prefix_no_match() {
+	char	*env[] = {"not=looking", "maybe=?looking", "key=forsure", "notmine=(null)", NULL};
+	char	*ret = expand_in_string("$ke", (const char **)env);
+	TEST_ASSERT_EQUAL_STRING("", ret);
+	free(ret);
+}
+
+void	test_expand_in_string_prefix_dollarsign_null() {
+	char	*env[] = {"not=looking", "maybe=?looking", "key=forsure", "notmine=(null)", NULL};
+	char	*ret = expand_in_string("$key$", (const char **)env);
+	TEST_ASSERT_EQUAL_STRING("forsure$", ret);
+	free(ret);
+}
+
+// void	test_expand_in_string_prefix_multiple() {
+// 	char	*env[] = {"not=looking", "maybe=?looking", "key=forsure", "notmine=(null)", NULL};
+// 	char	*ret = expand_in_string("$$key$notmine", (const char **)env);
+// 	TEST_ASSERT_EQUAL_STRING("$$forsure$notmine", ret);
+// 	// trim off until non-expanded key
+// 	free(ret);
+// }

--- a/test/env/test_unset.c
+++ b/test/env/test_unset.c
@@ -1,26 +1,20 @@
 #include "libft.h"
-#include "unset.c"
 #include "unity.h"
-#include "arr_utils.c"
-#include "occurs.c"
+#include "unset.c"
 #include "find_key.c"
-#include <string.h>
-#include "print_arr_sep.c"
-#include "support_shell.c"
+#include "arr_utils.c"
+#include "check_key.c"
+#include "occurs.c"
+#include "join_strings.c"
 
-void	test_ignore_remove_key_value() {
-	// char	*env[] = {"something=wrong", "this=false", "some=none", NULL};
-	// char	**arr = arr_dup((const char **)env);
-	// char	*key = strdup("this");
-	// char	**tmp = unset(arr, key);
-	// TEST_ASSERT_EQUAL(4, ft_strlen("this"));
-	// if (!tmp)
-	// 	TEST_FAIL();
-	// arr = tmp;
-	// char	*expected[] = {"something=wrong", "some=none", NULL};
-	// TEST_ASSERT_EQUAL_STRING_ARRAY(expected, arr, 3);
-	// TEST_ASSERT_EQUAL_STRING_ARRAY(expected, arr, 4);
-	// print_arr(arr);
-	// free(key);
-	// arr_free(arr);
+void	test_remove_key_value() {
+	char	*env[] = {"something=wrong", "this=false", "some=none", NULL};
+	char	**arr = arr_dup((const char **)env);
+	unset(((const char *[]){"unset", "this", NULL}), arr);
+	if (!arr)
+		TEST_FAIL();
+	char	*expected[] = {"something=wrong", "some=none", NULL};
+	TEST_ASSERT_EQUAL_STRING_ARRAY(expected, arr, 3);
+	TEST_ASSERT_EQUAL_STRING_ARRAY(expected, arr, 4);
+	arr_free(arr);
 }

--- a/test/env/test_unset.c
+++ b/test/env/test_unset.c
@@ -5,7 +5,7 @@
 #include "arr_utils.c"
 #include "check_key.c"
 #include "occurs.c"
-#include "join_strings.c"
+#include "free_strjoin.c"
 
 void	test_remove_key_value() {
 	char	*env[] = {"something=wrong", "this=false", "some=none", NULL};

--- a/test/parser/test_expand_variables.c
+++ b/test/parser/test_expand_variables.c
@@ -3,7 +3,7 @@
 #include "find_key.c"
 #include "utils.h"
 #include "expander.c"
-#include "join_strings.c"
+#include "free_strjoin.c"
 #include "check_key.c"
 
 void	test_expander() {
@@ -59,6 +59,7 @@ void	test_expander_two() {
 // echo $"PAGER"S -> echo PAGERS
 // echo $PAGER_S -> echo VAL
 
+// @audit single quotes
 void	test_expander_ignore_in_singlequotes() {
 	char	*line = "echo '$PAGER'";
 	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
@@ -74,291 +75,359 @@ void	test_expander_ignore_in_singlequotes() {
 	free(actual);
 }
 
-// void	test_expander_followed() {
-// 	char	*line = "echo $PAGER$TEST";
-// 	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
-// 	TEST_ASSERT_NOT_NULL(envp);
+void	test_expander_followed() {
+	char	*line = "echo $PAGER$TEST";
+	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
+	TEST_ASSERT_NOT_NULL(envp);
 
-// 	char	*expected_ret = "echo truefalse";
-// 	TEST_ASSERT_NOT_NULL(expected_ret);
+	char	*expected_ret = "echo truefalse";
+	TEST_ASSERT_NOT_NULL(expected_ret);
 
-// 	char	*actual = expander(line, (const char **)envp);
-// 	TEST_ASSERT_NOT_NULL(actual);
-// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
-// 	printf("%s\n", actual);
-// 	free(actual);
-// }
+	char	*actual = expander(line, (const char **)envp);
+	TEST_ASSERT_NOT_NULL(actual);
+	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+	printf("%s\n", actual);
+	free(actual);
+}
 
-// void	test_expander_followed_dq() {
-// 	char	*line = "echo \"$PAGER\"$TEST";
-// 	char	*envp[] ={ "PAGER=true", "TEST=false", NULL};
-// 	TEST_ASSERT_NOT_NULL(envp);
+void	test_expander_followed_dq() {
+	char	*line = "echo \"$PAGER\"$TEST";
+	char	*envp[] ={ "PAGER=true", "TEST=false", NULL};
+	TEST_ASSERT_NOT_NULL(envp);
 
-// 	char	*expected_ret = "echo \"true\"false";
-// 	TEST_ASSERT_NOT_NULL(expected_ret);
+	char	*expected_ret = "echo \"true\"false";
+	TEST_ASSERT_NOT_NULL(expected_ret);
 
-// 	char	*actual = expander(line, (const char **)envp);
-// 	TEST_ASSERT_NOT_NULL(actual);
-// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
-// 	printf("%s\n", actual);
-// 	free(actual);
-// }
+	char	*actual = expander(line, (const char **)envp);
+	TEST_ASSERT_NOT_NULL(actual);
+	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+	printf("%s\n", actual);
+	free(actual);
+}
 
-// void	test_expander_ignore_in_singlequotes_key() {
-// 	char	*line = "echo $'TEST'";
-// 	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
-// 	TEST_ASSERT_NOT_NULL(envp);
+void	test_expander_ignore_in_singlequotes_key() {
+	char	*line = "echo $'TEST'";
+	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
+	TEST_ASSERT_NOT_NULL(envp);
 
-// 	char	*expected_ret = "echo 'TEST'";
-// 	TEST_ASSERT_NOT_NULL(expected_ret);
+	char	*expected_ret = "echo 'TEST'";
+	TEST_ASSERT_NOT_NULL(expected_ret);
 
-// 	char	*actual = expander(line, (const char **)envp);
-// 	TEST_ASSERT_NOT_NULL(actual);
-// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
-// 	printf("%s\n", actual);
-// 	free(actual);
-// }
+	char	*actual = expander(line, (const char **)envp);
+	TEST_ASSERT_NOT_NULL(actual);
+	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+	printf("%s\n", actual);
+	free(actual);
+}
 
-// void	test_expander_ignore_in_doublequotes_key() {
-// 	char	*line = "$\"TEST\"";
-// 	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
-// 	TEST_ASSERT_NOT_NULL(envp);
+void	test_expander_ignore_in_doublequotes_key() {
+	char	*line = "$\"TEST\"";
+	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
+	TEST_ASSERT_NOT_NULL(envp);
 
-// 	char	*expected_ret = "$\"TEST\"";
-// 	TEST_ASSERT_NOT_NULL(expected_ret);
+	char	*expected_ret = "\"TEST\"";
+	TEST_ASSERT_NOT_NULL(expected_ret);
 
-// 	char	*actual = expander(line, (const char **)envp);
-// 	TEST_ASSERT_NOT_NULL(actual);
-// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
-// 	printf("%s\n", actual);
-// 	free(actual);
-// }
+	char	*actual = expander(line, (const char **)envp);
+	// TEST_ASSERT_NOT_NULL(actual);
+	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+	printf("%s\n", actual);
+	free(actual);
+}
 
-// void	test_expander_ignore_in_sq_key() {
-// 	char	*line = "echo $'TEST $TEST'";
-// 	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
-// 	TEST_ASSERT_NOT_NULL(envp);
+void	test_expander_ignore_in_sq_key() {
+	char	*line = "echo $'TEST $TEST'";
+	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
+	TEST_ASSERT_NOT_NULL(envp);
 
-// 	char	*expected_ret = "echo 'TEST $TEST'";
-// 	TEST_ASSERT_NOT_NULL(expected_ret);
+	char	*expected_ret = "echo 'TEST $TEST'";
+	TEST_ASSERT_NOT_NULL(expected_ret);
 
-// 	char	*actual = expander(line, (const char **)envp);
-// 	TEST_ASSERT_NOT_NULL(actual);
-// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
-// 	printf("%s\n", actual);
-// 	free(actual);
-// }
+	char	*actual = expander(line, (const char **)envp);
+	TEST_ASSERT_NOT_NULL(actual);
+	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+	printf("%s\n", actual);
+	free(actual);
+}
 
-// void	test_expander_ignore_in_doublequotes_key_two() {
-// 	char	*line = "echo \"$PAGER\"";
-// 	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
+void	test_expander_ignore_in_doublequotes_key_two() {
+	char	*line = "echo \"$PAGER\"";
+	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
 
-// 	char	*expected_ret = "echo \"true\"";
+	char	*expected_ret = "echo \"true\"";
 
-// 	char	*actual = expander(line, (const char **)envp);
-// 	TEST_ASSERT_NOT_NULL(actual);
-// 	printf("%s\n", actual);
-// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
-// 	free(actual);
-// }
-
-// // echo $'PAGER'S -> echo  PAGERS (remove $ and replace with space)
-// void	test_expander_followed_sq() {
-// 	char	*line = "echo $'PAGER'hello";
-// 	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
-// 	TEST_ASSERT_NOT_NULL(envp);
-
-// 	char	*expected_ret = "echo 'PAGER'hello";
-// 	TEST_ASSERT_NOT_NULL(expected_ret);
-
-// 	char	*actual = expander(line, (const char **)envp);
-// 	TEST_ASSERT_NOT_NULL(actual);
-// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
-// 	printf("%s\n", actual);
-// 	free(actual);
-// }
+	char	*actual = expander(line, (const char **)envp);
+	TEST_ASSERT_NOT_NULL(actual);
+	printf("%s\n", actual);
+	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+	free(actual);
+}
 
 // // echo $'PAGER'S -> echo  PAGERS (remove $ and replace with space)
-// void	test_expander_followed_sq_var() {
-// 	char	*line = "echo $'PAGER'$TEST";
-// 	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
-// 	TEST_ASSERT_NOT_NULL(envp);
+void	test_expander_followed_sq() {
+	char	*line = "echo $'PAGER'hello";
+	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
+	TEST_ASSERT_NOT_NULL(envp);
 
-// 	char	*expected_ret = "echo 'PAGER'false";
-// 	TEST_ASSERT_NOT_NULL(expected_ret);
+	char	*expected_ret = "echo 'PAGER'hello";
+	TEST_ASSERT_NOT_NULL(expected_ret);
 
-// 	char	*actual = expander(line, (const char **)envp);
-// 	TEST_ASSERT_NOT_NULL(actual);
-// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
-// 	printf("%s\n", actual);
-// 	free(actual);
-// }
+	char	*actual = expander(line, (const char **)envp);
+	TEST_ASSERT_NOT_NULL(actual);
+	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+	printf("%s\n", actual);
+	free(actual);
+}
+
+// echo $'PAGER'S -> echo  PAGERS (remove $ and replace with space)
+void	test_expander_followed_sq_var() {
+	char	*line = "echo $'PAGER'$TEST";
+	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
+	TEST_ASSERT_NOT_NULL(envp);
+
+	char	*expected_ret = "echo 'PAGER'false";
+	TEST_ASSERT_NOT_NULL(expected_ret);
+
+	char	*actual = expander(line, (const char **)envp);
+	TEST_ASSERT_NOT_NULL(actual);
+	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+	printf("%s\n", actual);
+	free(actual);
+}
 
 // // should this case even be implemented?
-// void	test_error_invalid_name() {
-// 	char	*line = "echo $'PA?GER'$test";
-// 	char	*envp[] = {"PA?GER=true", "test=false", NULL};
-// 	TEST_ASSERT_NOT_NULL(envp);
+void	test_error_invalid_name() {
+	char	*line = "echo $'PA?GER'$test";
+	char	*envp[] = {"PA?GER=true", "test=false", NULL};
+	TEST_ASSERT_NOT_NULL(envp);
 
-// 	char	*expected_ret = "echo 'PA?GER'false";
-// 	TEST_ASSERT_NOT_NULL(expected_ret);
+	char	*expected_ret = "echo 'PA?GER'false";
+	TEST_ASSERT_NOT_NULL(expected_ret);
 
-// 	char	*actual = expander(line, (const char **)envp);
-// 	TEST_ASSERT_NOT_NULL(actual);
-// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
-// 	printf("%s\n", actual);
-// 	free(actual);
-// }
+	char	*actual = expander(line, (const char **)envp);
+	TEST_ASSERT_NOT_NULL(actual);
+	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+	printf("%s\n", actual);
+	free(actual);
+}
 
-// void	test_replace_key_not_found_name() {
-// 	char	*line = "$hello";
-// 	char	*envp[] = {"PAGER=true", "test=false", NULL};
-// 	TEST_ASSERT_NOT_NULL(envp);
+void	test_replace_key_not_found_name() {
+	char	*line = "$hello";
+	char	*envp[] = {"PAGER=true", "test=false", NULL};
+	TEST_ASSERT_NOT_NULL(envp);
 
-// 	char	*expected_ret = "";
-// 	TEST_ASSERT_NOT_NULL(expected_ret);
+	char	*expected_ret = "";
+	TEST_ASSERT_NOT_NULL(expected_ret);
 
-// 	char	*actual = expander(line, (const char **)envp);
-// 	TEST_ASSERT_NOT_NULL(actual);
-// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
-// 	printf("%s\n", actual);
-// 	free(actual);
-// }
+	char	*actual = expander(line, (const char **)envp);
+	TEST_ASSERT_NOT_NULL(actual);
+	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+	free(actual);
+}
 
-// void	test_key_not_found_name() {
-// 	char	*line = "$h_echo";
-// 	char	*envp[] = {"PAGER=true", "test=false", NULL};
-// 	TEST_ASSERT_NOT_NULL(envp);
+void	test_key_not_found_name() {
+	char	*line = "$h_echo";
+	char	*envp[] = {"PAGER=true", "test=false", NULL};
+	TEST_ASSERT_NOT_NULL(envp);
 
-// 	char	*expected_ret = "";
-// 	TEST_ASSERT_NOT_NULL(expected_ret);
+	char	*expected_ret = "";
+	TEST_ASSERT_NOT_NULL(expected_ret);
 
-// 	char	*actual = expander(line, (const char **)envp);
-// 	TEST_ASSERT_NOT_NULL(actual);
-// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
-// 	printf("%s\n", actual);
-// 	free(actual);
-// }
+	char	*actual = expander(line, (const char **)envp);
+	TEST_ASSERT_NOT_NULL(actual);
+	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+	printf("%s\n", actual);
+	free(actual);
+}
 
-// #include "print_arr_sep.c"
-// #include "occurs.c"
-// char	**arr_map(char **arr, void *(*f)(void *, void *), void *arg);
+#include "print_arr_sep.c"
+#include "occurs.c"
+char	**arr_map(char **arr, void *(*f)(void *, void *), void *arg);
 
-// #include "arr_utils.c"
-// // void	test_expansion_space_follows() {
-// // 	char	**split_tokens = arr_dup((const char *[]){"ls -l $somedir ' '", "cat -e", "wc -l", NULL});
+#include "arr_utils.c"
+void	test_expansion_space_follows() {
+	char	**split_tokens = arr_dup((const char *[]){"ls -l $somedir ' '", "cat -e", "wc -l", NULL});
 
-// // 	// trim beforehand
-// // 	char	**split_tokens_trim_spaces = arr_trim(split_tokens, " ");
-// // 	char	**expected = (char *[]){"ls -l $somedir ' '", "cat -e", "wc -l", NULL};
-// // 	TEST_ASSERT_EQUAL_STRING_ARRAY(expected, split_tokens_trim_spaces, 4);
-// // 	char	**envp = arr_dup((const char **)((char *[]){"PATH=/usr/bin", "HOME=/home/user", "USER=user", "somedir=you", NULL}));
+	// trim beforehand
+	char	**split_tokens_trim_spaces = arr_trim(split_tokens, " ");
+	char	**expected = (char *[]){"ls -l $somedir ' '", "cat -e", "wc -l", NULL};
+	TEST_ASSERT_EQUAL_STRING_ARRAY(expected, split_tokens_trim_spaces, 4);
+	char	**envp = arr_dup((const char **)((char *[]){"PATH=/usr/bin", "HOME=/home/user", "USER=user", "somedir=you", NULL}));
 
-// // 	char	**expanded = arr_map(split_tokens_trim_spaces, (void *)expander, (void *)envp);
-// // 	TEST_ASSERT_NOT_NULL(expanded);
+	char	**expanded = arr_map(split_tokens_trim_spaces, (void *)expander, (void *)envp);
+	TEST_ASSERT_NOT_NULL(expanded);
 
-// // 	char	**expected_expanded = (char *[]){"ls -l you ' '", "cat -e", "wc -l", NULL};
+	char	**expected_expanded = (char *[]){"ls -l you ' '", "cat -e", "wc -l", NULL};
 
-// // 	TEST_ASSERT_EQUAL_STRING_ARRAY(expected_expanded, expanded, 4);
-// // 	arr_free(expanded);
-// // 	arr_free(envp);
-// // 	arr_free(split_tokens_trim_spaces);
-// // 	arr_free(split_tokens);
-// // }
+	TEST_ASSERT_EQUAL_STRING_ARRAY(expected_expanded, expanded, 4);
+	arr_free(expanded);
+	arr_free(envp);
+	arr_free(split_tokens_trim_spaces);
+	arr_free(split_tokens);
+}
 
-// char	**arr_map(char **arr, void *(*f)(void *, void *), void *arg)
-// {
-// 	size_t	i;
-// 	char	**ret;
+char	**arr_map(char **arr, void *(*f)(void *, void *), void *arg)
+{
+	size_t	i;
+	char	**ret;
 
-// 	i = 0;
-// 	ret = (char **)ft_calloc(arr_len((const char **)arr) + 1, sizeof(char *));
-// 	if (!ret)
-// 		return (NULL);
-// 	while (arr[i])
-// 	{
-// 		ret[i] = f(arr[i], arg);
-// 		i++;
-// 	}
-// 	return (ret);
-// }
+	i = 0;
+	ret = (char **)ft_calloc(arr_len((const char **)arr) + 1, sizeof(char *));
+	if (!ret)
+		return (NULL);
+	while (arr[i])
+	{
+		ret[i] = f(arr[i], arg);
+		i++;
+	}
+	return (ret);
+}
 
-// // void	test_expansion_space_follows_non_null() {
-// // 	char	**split_tokens = arr_dup((const char *[]){"ls -l $somedir ' '", "cat -e", "wc -l", NULL});
+void	test_expansion_space_follows_non_null() {
+	char	**split_tokens = arr_dup((const char *[]){"ls -l $somedir ' '", "cat -e", "wc -l", NULL});
 
-// // 	// trim beforehand
-// // 	char	**split_tokens_trim_spaces = arr_trim(split_tokens, " ");
-// // 	char	**expected = (char *[]){"ls -l $somedir ' '", "cat -e", "wc -l", NULL};
-// // 	TEST_ASSERT_EQUAL_STRING_ARRAY(expected, split_tokens_trim_spaces, 4);
-// // 	char	**envp = arr_dup((const char **)((char *[]){"PATH=/usr/bin", "HOME=/home/user", "USER=user", "somedir=you", NULL}));
+	// trim beforehand
+	char	**split_tokens_trim_spaces = arr_trim(split_tokens, " ");
+	char	**expected = (char *[]){"ls -l $somedir ' '", "cat -e", "wc -l", NULL};
+	TEST_ASSERT_EQUAL_STRING_ARRAY(expected, split_tokens_trim_spaces, 4);
+	char	**envp = arr_dup((const char **)((char *[]){"PATH=/usr/bin", "HOME=/home/user", "USER=user", "somedir=you", NULL}));
 
-// // 	char	**expanded = arr_map(split_tokens_trim_spaces, (void *)expander, (void *)envp);
+	char	**expanded = arr_map(split_tokens_trim_spaces, (void *)expander, (void *)envp);
 
-// // 	char	**expected_expanded = (char *[]){"ls -l you ' '", "cat -e", "wc -l", NULL};
+	char	**expected_expanded = (char *[]){"ls -l you ' '", "cat -e", "wc -l", NULL};
 
-// // 	TEST_ASSERT_EQUAL_STRING_ARRAY(expected_expanded, expanded, 4);
+	TEST_ASSERT_EQUAL_STRING_ARRAY(expected_expanded, expanded, 4);
 
-// // 	arr_free(envp);
-// // 	arr_free(split_tokens_trim_spaces);
-// // 	arr_free(split_tokens);
-// // 	arr_free(expanded);
-// // }
+	arr_free(envp);
+	arr_free(split_tokens_trim_spaces);
+	arr_free(split_tokens);
+	arr_free(expanded);
+}
 
-// void	test_expansion_followed_dollarsign() {
+void	test_expansion_followed_dollarsign() {
 
-// 	char	**split_tokens = arr_dup((const char **)(char *[]){"ls -l $somedir", "cat -e", "wc -l", NULL});
+	char	**split_tokens = arr_dup((const char **)(char *[]){"ls -l $somedir", "cat -e", "wc -l", NULL});
 
-// 	char	**split_tokens_trim_spaces = arr_trim(split_tokens, " ");
+	char	**split_tokens_trim_spaces = arr_trim(split_tokens, " ");
 
-// 	char	**envp = arr_dup((const char **)((char *[]){"PATH=/usr/bin", "HOME=/home/user", "USER=user", "somedir=$otherdir", "otherdir=mypath$", NULL}));
+	char	**envp = arr_dup((const char **)((char *[]){"PATH=/usr/bin", "HOME=/home/user", "USER=user", "somedir=$otherdir", "otherdir=mypath$", NULL}));
 
-// 	TEST_ASSERT_EQUAL_STRING("ls -l $somedir", split_tokens_trim_spaces[0]);
+	TEST_ASSERT_EQUAL_STRING("ls -l $somedir", split_tokens_trim_spaces[0]);
 
-// 	char	*tmp;
-// 	while (str_cchr(split_tokens_trim_spaces[0], '$') != 0)
-// 	{
-// 		tmp = expander(split_tokens_trim_spaces[0], (const char **)envp);
-// 		TEST_ASSERT_NOT_NULL(tmp);
-// 		if (ft_strncmp(tmp, split_tokens_trim_spaces[0], ft_strlen(tmp)) == 0)
-// 		{
-// 			free(tmp);
-// 			break;
-// 		}
-// 		free(split_tokens_trim_spaces[0]);
-// 		split_tokens_trim_spaces[0] = tmp;
-// 	}
+	char	*tmp;
+	while (str_cchr(split_tokens_trim_spaces[0], '$') != 0)
+	{
+		tmp = expander(split_tokens_trim_spaces[0], (const char **)envp);
+		TEST_ASSERT_NOT_NULL(tmp);
+		if (ft_strncmp(tmp, split_tokens_trim_spaces[0], ft_strlen(tmp)) == 0)
+		{
+			free(tmp);
+			break;
+		}
+		free(split_tokens_trim_spaces[0]);
+		split_tokens_trim_spaces[0] = tmp;
+	}
 
-// 	char	**expected_expanded = (char *[]){"ls -l mypath$", "cat -e", "wc -l", NULL};
+	char	**expected_expanded = (char *[]){"ls -l mypath$", "cat -e", "wc -l", NULL};
 
-// 	TEST_ASSERT_EQUAL_STRING(expected_expanded[0], split_tokens_trim_spaces[0]);
+	TEST_ASSERT_EQUAL_STRING(expected_expanded[0], split_tokens_trim_spaces[0]);
 
-// 	arr_free(envp);
-// 	arr_free(split_tokens);
-// 	arr_free(split_tokens_trim_spaces);
-// }
+	arr_free(envp);
+	arr_free(split_tokens);
+	arr_free(split_tokens_trim_spaces);
+}
 
-// void	test_input_prefix_dollar() {
-// 	char	*line = "$$PAGER";
-// 	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
+void	test_input_prefix_dollar() {
+	char	*line = "$$PAGER";
+	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
 
-// 	char	*expected_ret = "$true";
+	char	*expected_ret = "$true";
 
-// 	char	*actual = expander(line, (const char **)envp);
-// 	TEST_ASSERT_NOT_NULL(actual);
-// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
-// 	printf("%s\n", actual);
-// 	free(actual);
-// }
+	char	*actual = expander(line, (const char **)envp);
+	TEST_ASSERT_NOT_NULL(actual);
+	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+	printf("%s\n", actual);
+	free(actual);
+}
 
-// void	test_input_prefix_dollar_two() {
-// 	char	*line = "$$PAGER";
-// 	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
-// 	TEST_ASSERT_NOT_NULL(envp);
+void	test_input_prefix_dollar_two() {
+	char	*line = "$$PAGER";
+	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
+	TEST_ASSERT_NOT_NULL(envp);
 
-// 	char	*expected_ret = "$true";
+	char	*expected_ret = "$true";
 
-// 	char	*actual = expander(line, (const char **)envp);
+	char	*actual = expander(line, (const char **)envp);
 
-// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
-// 	free(actual);
-// }
+	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+	free(actual);
+}
+
+void	test_get_exit_status() {
+	char	*line = "echo $?";
+	char	*envp[] = {"PAGER=true", "TEST=false", "?=0", NULL};
+	TEST_ASSERT_NOT_NULL(envp);
+
+	char	*expected_ret = "echo 0";
+
+	char	*actual = expander(line, (const char **)envp);
+	TEST_ASSERT_NOT_NULL(actual);
+	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+	printf("%s\n", actual);
+	free(actual);
+}
+
+void	test_get_exit_status_other() {
+	char	*line = "$hello $?$none$some";
+	char	*envp[] = {"PAGER=true", "TEST=false", "?=1", "hello=echo", "some=thing", NULL};
+	TEST_ASSERT_NOT_NULL(envp);
+
+	char	*expected_ret = "echo 1thing";
+
+	char	*actual = expander(line, (const char **)envp);
+	TEST_ASSERT_NOT_NULL(actual);
+	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+	printf("%s\n", actual);
+	free(actual);
+}
+
+void	test_get_exit_status_single() {
+	char	*line = "$?";
+	char	*envp[] = {"PAGER=true", "TEST=false", "?=1", "hello=echo", "some=thing", NULL};
+	TEST_ASSERT_NOT_NULL(envp);
+
+	char	*expected_ret = "1";
+
+	char	*actual = expander(line, (const char **)envp);
+	TEST_ASSERT_NOT_NULL(actual);
+	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+	printf("%s\n", actual);
+	free(actual);
+}
+
+void	test_get_exit_status_mult() {
+	char	*line = "$?$$?$?$$$$hello?$";
+	char	*envp[] = {"PAGER=true", "TEST=false", "?=1", "hello=echo", "some=thing", NULL};
+	TEST_ASSERT_NOT_NULL(envp);
+
+	char	*expected_ret = "1$11$$$echo?$";
+
+	char	*actual = expander(line, (const char **)envp);
+	TEST_ASSERT_NOT_NULL(actual);
+	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+	printf("%s\n", actual);
+	free(actual);
+}
+void	test_nothing_to_do() {
+	char	*line = "something";
+	char	*envp[] = {"PAGER=true", "TEST=false", "?=1", "hello=echo", "some=thing", NULL};
+	TEST_ASSERT_NOT_NULL(envp);
+
+	char	*expected_ret = "something";
+
+	char	*actual = expander(line, (const char **)envp);
+	TEST_ASSERT_NOT_NULL(actual);
+	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+	printf("%s\n", actual);
+	free(actual);
+}

--- a/test/parser/test_expand_variables.c
+++ b/test/parser/test_expand_variables.c
@@ -2,8 +2,9 @@
 #include "unity.h"
 #include "find_key.c"
 #include "utils.h"
-#include "expander.h"
-#include "expand_variables.c"
+#include "expander.c"
+#include "join_strings.c"
+#include "check_key.c"
 
 void	test_expander() {
 	char	*line = "echo $PAGER";
@@ -14,7 +15,7 @@ void	test_expander() {
 	char	*expected_ret = "echo true";
 	TEST_ASSERT_NOT_NULL(expected_ret);
 
-	char	*expanded_line = expand_variables(line, (const char **)envp);
+	char	*expanded_line = expander(line, (const char **)envp);
 	TEST_ASSERT_NOT_NULL(expanded_line);
 	TEST_ASSERT_EQUAL_STRING(expected_ret, expanded_line);
 	free(expanded_line);
@@ -29,8 +30,7 @@ void	test_expander_mult() {
 	char	*expected_ret = "echo true | echo false";
 	TEST_ASSERT_NOT_NULL(expected_ret);
 
-	char	*expanded_line = expand_variables(line, (const char **)envp);
-	TEST_ASSERT_NOT_NULL(expanded_line);
+	char	*expanded_line = expander(line, (const char **)envp);
 	TEST_ASSERT_EQUAL_STRING(expected_ret, expanded_line);
 	free(expanded_line);
 }
@@ -43,7 +43,7 @@ void	test_expander_two() {
 	char	*expected_ret = "echo true | echo \"false\" | echo false | echo true";
 	TEST_ASSERT_NOT_NULL(expected_ret);
 
-	char	*actual = expand_variables(line, (const char **)envp);
+	char	*actual = expander(line, (const char **)envp);
 	TEST_ASSERT_NOT_NULL(actual);
 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
 	printf("%s\n", actual);
@@ -51,13 +51,13 @@ void	test_expander_two() {
 }
 
 
-// // echo hello$PAGER -> echo helloVAL
-// // echo "$PAGER" -> echo VAL
-// // echo $PAGER -> echo VAL
-// // echo $'PAGER'S -> echo PAGERS (remove $)
-// // echo '$PAGER' -> echo $PAGER
-// // echo $"PAGER"S -> echo PAGERS
-// // echo $PAGER_S -> echo VAL
+// echo hello$PAGER -> echo helloVAL
+// echo "$PAGER" -> echo VAL
+// echo $PAGER -> echo VAL
+// echo $'PAGER'S -> echo PAGERS (remove $)
+// echo '$PAGER' -> echo $PAGER
+// echo $"PAGER"S -> echo PAGERS
+// echo $PAGER_S -> echo VAL
 
 void	test_expander_ignore_in_singlequotes() {
 	char	*line = "echo '$PAGER'";
@@ -67,273 +67,298 @@ void	test_expander_ignore_in_singlequotes() {
 	char	*expected_ret = "echo '$PAGER'";
 	TEST_ASSERT_NOT_NULL(expected_ret);
 
-	char	*actual = expand_variables(line, (const char **)envp);
+	char	*actual = expander(line, (const char **)envp);
 	TEST_ASSERT_NOT_NULL(actual);
 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
 	printf("%s\n", actual);
 	free(actual);
 }
 
-void	test_expander_followed() {
-	char	*line = "echo $PAGER$TEST";
-	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
-	TEST_ASSERT_NOT_NULL(envp);
+// void	test_expander_followed() {
+// 	char	*line = "echo $PAGER$TEST";
+// 	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
+// 	TEST_ASSERT_NOT_NULL(envp);
 
-	char	*expected_ret = "echo truefalse";
-	TEST_ASSERT_NOT_NULL(expected_ret);
+// 	char	*expected_ret = "echo truefalse";
+// 	TEST_ASSERT_NOT_NULL(expected_ret);
 
-	char	*actual = expand_variables(line, (const char **)envp);
-	TEST_ASSERT_NOT_NULL(actual);
-	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
-	printf("%s\n", actual);
-	free(actual);
-}
+// 	char	*actual = expander(line, (const char **)envp);
+// 	TEST_ASSERT_NOT_NULL(actual);
+// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+// 	printf("%s\n", actual);
+// 	free(actual);
+// }
 
-void	test_expander_followed_dq() {
-	char	*line = "echo \"$PAGER\"$TEST";
-	char	*envp[] ={ "PAGER=true", "TEST=false", NULL};
-	TEST_ASSERT_NOT_NULL(envp);
+// void	test_expander_followed_dq() {
+// 	char	*line = "echo \"$PAGER\"$TEST";
+// 	char	*envp[] ={ "PAGER=true", "TEST=false", NULL};
+// 	TEST_ASSERT_NOT_NULL(envp);
 
-	char	*expected_ret = "echo \"true\"false";
-	TEST_ASSERT_NOT_NULL(expected_ret);
+// 	char	*expected_ret = "echo \"true\"false";
+// 	TEST_ASSERT_NOT_NULL(expected_ret);
 
-	char	*actual = expand_variables(line, (const char **)envp);
-	TEST_ASSERT_NOT_NULL(actual);
-	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
-	printf("%s\n", actual);
-	free(actual);
-}
+// 	char	*actual = expander(line, (const char **)envp);
+// 	TEST_ASSERT_NOT_NULL(actual);
+// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+// 	printf("%s\n", actual);
+// 	free(actual);
+// }
 
-void	test_expander_ignore_in_singlequotes_key() {
-	char	*line = "echo $'TEST'";
-	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
-	TEST_ASSERT_NOT_NULL(envp);
+// void	test_expander_ignore_in_singlequotes_key() {
+// 	char	*line = "echo $'TEST'";
+// 	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
+// 	TEST_ASSERT_NOT_NULL(envp);
 
-	char	*expected_ret = "echo  'TEST'";
-	TEST_ASSERT_NOT_NULL(expected_ret);
+// 	char	*expected_ret = "echo 'TEST'";
+// 	TEST_ASSERT_NOT_NULL(expected_ret);
 
-	char	*actual = expand_variables(line, (const char **)envp);
-	TEST_ASSERT_NOT_NULL(actual);
-	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
-	printf("%s\n", actual);
-	free(actual);
-}
+// 	char	*actual = expander(line, (const char **)envp);
+// 	TEST_ASSERT_NOT_NULL(actual);
+// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+// 	printf("%s\n", actual);
+// 	free(actual);
+// }
 
-void	test_expander_ignore_in_doublequotes_key() {
-	char	*line = "echo $\"TEST\"";
-	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
-	TEST_ASSERT_NOT_NULL(envp);
+// void	test_expander_ignore_in_doublequotes_key() {
+// 	char	*line = "$\"TEST\"";
+// 	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
+// 	TEST_ASSERT_NOT_NULL(envp);
 
-	char	*expected_ret = "echo  \"TEST\"";
-	TEST_ASSERT_NOT_NULL(expected_ret);
+// 	char	*expected_ret = "$\"TEST\"";
+// 	TEST_ASSERT_NOT_NULL(expected_ret);
 
-	char	*actual = expand_variables(line, (const char **)envp);
-	TEST_ASSERT_NOT_NULL(actual);
-	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
-	printf("%s\n", actual);
-	free(actual);
-}
+// 	char	*actual = expander(line, (const char **)envp);
+// 	TEST_ASSERT_NOT_NULL(actual);
+// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+// 	printf("%s\n", actual);
+// 	free(actual);
+// }
 
-void	test_expander_ignore_in_sq_key() {
-	char	*line = "echo $'TEST $TEST'";
-	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
-	TEST_ASSERT_NOT_NULL(envp);
+// void	test_expander_ignore_in_sq_key() {
+// 	char	*line = "echo $'TEST $TEST'";
+// 	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
+// 	TEST_ASSERT_NOT_NULL(envp);
 
-	char	*expected_ret = "echo  'TEST $TEST'";
-	TEST_ASSERT_NOT_NULL(expected_ret);
+// 	char	*expected_ret = "echo 'TEST $TEST'";
+// 	TEST_ASSERT_NOT_NULL(expected_ret);
 
-	char	*actual = expand_variables(line, (const char **)envp);
-	TEST_ASSERT_NOT_NULL(actual);
-	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
-	printf("%s\n", actual);
-	free(actual);
-}
+// 	char	*actual = expander(line, (const char **)envp);
+// 	TEST_ASSERT_NOT_NULL(actual);
+// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+// 	printf("%s\n", actual);
+// 	free(actual);
+// }
 
-void	test_expander_ignore_in_doublequotes_key_two() {
-	char	*line = "echo \"$PAGER\"";
-	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
+// void	test_expander_ignore_in_doublequotes_key_two() {
+// 	char	*line = "echo \"$PAGER\"";
+// 	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
 
-	char	*expected_ret = "echo \"true\"";
+// 	char	*expected_ret = "echo \"true\"";
 
-	char	*actual = expand_variables(line, (const char **)envp);
-	TEST_ASSERT_NOT_NULL(actual);
-	printf("%s\n", actual);
-	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
-	free(actual);
-}
+// 	char	*actual = expander(line, (const char **)envp);
+// 	TEST_ASSERT_NOT_NULL(actual);
+// 	printf("%s\n", actual);
+// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+// 	free(actual);
+// }
 
-// echo $'PAGER'S -> echo  PAGERS (remove $ and replace with space)
-void	test_expander_followed_sq() {
-	char	*line = "echo $'PAGER'hello";
-	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
-	TEST_ASSERT_NOT_NULL(envp);
+// // echo $'PAGER'S -> echo  PAGERS (remove $ and replace with space)
+// void	test_expander_followed_sq() {
+// 	char	*line = "echo $'PAGER'hello";
+// 	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
+// 	TEST_ASSERT_NOT_NULL(envp);
 
-	char	*expected_ret = "echo  'PAGER'hello";
-	TEST_ASSERT_NOT_NULL(expected_ret);
+// 	char	*expected_ret = "echo 'PAGER'hello";
+// 	TEST_ASSERT_NOT_NULL(expected_ret);
 
-	char	*actual = expand_variables(line, (const char **)envp);
-	TEST_ASSERT_NOT_NULL(actual);
-	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
-	printf("%s\n", actual);
-	free(actual);
-}
+// 	char	*actual = expander(line, (const char **)envp);
+// 	TEST_ASSERT_NOT_NULL(actual);
+// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+// 	printf("%s\n", actual);
+// 	free(actual);
+// }
 
-// echo $'PAGER'S -> echo  PAGERS (remove $ and replace with space)
-void	test_expander_followed_sq_var() {
-	char	*line = "echo $'PAGER'$TEST";
-	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
-	TEST_ASSERT_NOT_NULL(envp);
+// // echo $'PAGER'S -> echo  PAGERS (remove $ and replace with space)
+// void	test_expander_followed_sq_var() {
+// 	char	*line = "echo $'PAGER'$TEST";
+// 	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
+// 	TEST_ASSERT_NOT_NULL(envp);
 
-	char	*expected_ret = "echo  'PAGER'false";
-	TEST_ASSERT_NOT_NULL(expected_ret);
+// 	char	*expected_ret = "echo 'PAGER'false";
+// 	TEST_ASSERT_NOT_NULL(expected_ret);
 
-	char	*actual = expand_variables(line, (const char **)envp);
-	TEST_ASSERT_NOT_NULL(actual);
-	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
-	printf("%s\n", actual);
-	free(actual);
-}
+// 	char	*actual = expander(line, (const char **)envp);
+// 	TEST_ASSERT_NOT_NULL(actual);
+// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+// 	printf("%s\n", actual);
+// 	free(actual);
+// }
 
-// should this case even be implemented?
-void	test_error_invalid_name() {
-	char	*line = "echo $'PA?GER'$test";
-	char	*envp[] = {"PA?GER=true", "test=false", NULL};
-	TEST_ASSERT_NOT_NULL(envp);
+// // should this case even be implemented?
+// void	test_error_invalid_name() {
+// 	char	*line = "echo $'PA?GER'$test";
+// 	char	*envp[] = {"PA?GER=true", "test=false", NULL};
+// 	TEST_ASSERT_NOT_NULL(envp);
 
-	char	*expected_ret = "echo  'PA?GER'false";
-	TEST_ASSERT_NOT_NULL(expected_ret);
+// 	char	*expected_ret = "echo 'PA?GER'false";
+// 	TEST_ASSERT_NOT_NULL(expected_ret);
 
-	char	*actual = expand_variables(line, (const char **)envp);
-	TEST_ASSERT_NOT_NULL(actual);
-	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
-	printf("%s\n", actual);
-	free(actual);
-}
+// 	char	*actual = expander(line, (const char **)envp);
+// 	TEST_ASSERT_NOT_NULL(actual);
+// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+// 	printf("%s\n", actual);
+// 	free(actual);
+// }
 
-void	test_replace_key_not_found_name() {
-	char	*line = "echo $hello";
-	char	*envp[] = {"PAGER=true", "test=false", NULL};
-	TEST_ASSERT_NOT_NULL(envp);
+// void	test_replace_key_not_found_name() {
+// 	char	*line = "$hello";
+// 	char	*envp[] = {"PAGER=true", "test=false", NULL};
+// 	TEST_ASSERT_NOT_NULL(envp);
 
-	char	*expected_ret = "echo ";
-	TEST_ASSERT_NOT_NULL(expected_ret);
+// 	char	*expected_ret = "";
+// 	TEST_ASSERT_NOT_NULL(expected_ret);
 
-	char	*actual = expand_variables(line, (const char **)envp);
-	TEST_ASSERT_NOT_NULL(actual);
-	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
-	printf("%s\n", actual);
-	free(actual);
-}
+// 	char	*actual = expander(line, (const char **)envp);
+// 	TEST_ASSERT_NOT_NULL(actual);
+// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+// 	printf("%s\n", actual);
+// 	free(actual);
+// }
 
-// weird stuff with invalid names
-void	test_invalid_key_found_name() {
-	char	*line = "echo $h?echo";
-	char	*envp[] = {"PAGER=true", "test=false", NULL};
-	TEST_ASSERT_NOT_NULL(envp);
+// void	test_key_not_found_name() {
+// 	char	*line = "$h_echo";
+// 	char	*envp[] = {"PAGER=true", "test=false", NULL};
+// 	TEST_ASSERT_NOT_NULL(envp);
 
-	char	*expected_ret = "echo ?echo";
-	TEST_ASSERT_NOT_NULL(expected_ret);
+// 	char	*expected_ret = "";
+// 	TEST_ASSERT_NOT_NULL(expected_ret);
 
-	char	*actual = expand_variables(line, (const char **)envp);
-	TEST_ASSERT_NOT_NULL(actual);
-	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
-	printf("%s\n", actual);
-	free(actual);
-}
+// 	char	*actual = expander(line, (const char **)envp);
+// 	TEST_ASSERT_NOT_NULL(actual);
+// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+// 	printf("%s\n", actual);
+// 	free(actual);
+// }
 
-#include "print_arr_sep.c"
-#include "occurs.c"
-char	**arr_map(char **arr, void *(*f)(void *, void *), void *arg);
+// #include "print_arr_sep.c"
+// #include "occurs.c"
+// char	**arr_map(char **arr, void *(*f)(void *, void *), void *arg);
 
-#include "arr_utils.c"
-void	test_expansion_space_follows() {
-	char	**split_tokens = arr_dup((const char *[]){"ls -l $somedir ' '", "cat -e", "wc -l", NULL});
+// #include "arr_utils.c"
+// // void	test_expansion_space_follows() {
+// // 	char	**split_tokens = arr_dup((const char *[]){"ls -l $somedir ' '", "cat -e", "wc -l", NULL});
 
-	// trim beforehand
-	char	**split_tokens_trim_spaces = arr_trim(split_tokens, " ");
-	char	**expected = (char *[]){"ls -l $somedir ' '", "cat -e", "wc -l", NULL};
-	TEST_ASSERT_EQUAL_STRING_ARRAY(expected, split_tokens_trim_spaces, 4);
-	char	**envp = arr_dup((const char **)((char *[]){"PATH=/usr/bin", "HOME=/home/user", "USER=user", "somedir=you", NULL}));
+// // 	// trim beforehand
+// // 	char	**split_tokens_trim_spaces = arr_trim(split_tokens, " ");
+// // 	char	**expected = (char *[]){"ls -l $somedir ' '", "cat -e", "wc -l", NULL};
+// // 	TEST_ASSERT_EQUAL_STRING_ARRAY(expected, split_tokens_trim_spaces, 4);
+// // 	char	**envp = arr_dup((const char **)((char *[]){"PATH=/usr/bin", "HOME=/home/user", "USER=user", "somedir=you", NULL}));
 
-	char	**expanded = arr_map(split_tokens_trim_spaces, (void *)expand_variables, (void *)envp);
-	TEST_ASSERT_NOT_NULL(expanded);
+// // 	char	**expanded = arr_map(split_tokens_trim_spaces, (void *)expander, (void *)envp);
+// // 	TEST_ASSERT_NOT_NULL(expanded);
 
-	char	**expected_expanded = (char *[]){"ls -l you ' '", "cat -e", "wc -l", NULL};
+// // 	char	**expected_expanded = (char *[]){"ls -l you ' '", "cat -e", "wc -l", NULL};
 
-	TEST_ASSERT_EQUAL_STRING_ARRAY(expected_expanded, expanded, 4);
-	arr_free(expanded);
-	arr_free(envp);
-	arr_free(split_tokens_trim_spaces);
-	arr_free(split_tokens);
-}
+// // 	TEST_ASSERT_EQUAL_STRING_ARRAY(expected_expanded, expanded, 4);
+// // 	arr_free(expanded);
+// // 	arr_free(envp);
+// // 	arr_free(split_tokens_trim_spaces);
+// // 	arr_free(split_tokens);
+// // }
 
-char	**arr_map(char **arr, void *(*f)(void *, void *), void *arg)
-{
-	size_t	i;
-	char	**ret;
+// char	**arr_map(char **arr, void *(*f)(void *, void *), void *arg)
+// {
+// 	size_t	i;
+// 	char	**ret;
 
-	i = 0;
-	ret = (char **)ft_calloc(arr_len((const char **)arr) + 1, sizeof(char *));
-	if (!ret)
-		return (NULL);
-	while (arr[i])
-	{
-		ret[i] = f(arr[i], arg);
-		i++;
-	}
-	return (ret);
-}
+// 	i = 0;
+// 	ret = (char **)ft_calloc(arr_len((const char **)arr) + 1, sizeof(char *));
+// 	if (!ret)
+// 		return (NULL);
+// 	while (arr[i])
+// 	{
+// 		ret[i] = f(arr[i], arg);
+// 		i++;
+// 	}
+// 	return (ret);
+// }
 
-void	test_expansion_space_follows_non_null() {
-	char	**split_tokens = arr_dup((const char *[]){"ls -l $somedir ' '", "cat -e", "wc -l", NULL});
+// // void	test_expansion_space_follows_non_null() {
+// // 	char	**split_tokens = arr_dup((const char *[]){"ls -l $somedir ' '", "cat -e", "wc -l", NULL});
 
-	// trim beforehand
-	char	**split_tokens_trim_spaces = arr_trim(split_tokens, " ");
-	char	**expected = (char *[]){"ls -l $somedir ' '", "cat -e", "wc -l", NULL};
-	TEST_ASSERT_EQUAL_STRING_ARRAY(expected, split_tokens_trim_spaces, 4);
-	char	**envp = arr_dup((const char **)((char *[]){"PATH=/usr/bin", "HOME=/home/user", "USER=user", "somedir=you", NULL}));
+// // 	// trim beforehand
+// // 	char	**split_tokens_trim_spaces = arr_trim(split_tokens, " ");
+// // 	char	**expected = (char *[]){"ls -l $somedir ' '", "cat -e", "wc -l", NULL};
+// // 	TEST_ASSERT_EQUAL_STRING_ARRAY(expected, split_tokens_trim_spaces, 4);
+// // 	char	**envp = arr_dup((const char **)((char *[]){"PATH=/usr/bin", "HOME=/home/user", "USER=user", "somedir=you", NULL}));
 
-	char	**expanded = arr_map(split_tokens_trim_spaces, (void *)expand_variables, (void *)envp);
+// // 	char	**expanded = arr_map(split_tokens_trim_spaces, (void *)expander, (void *)envp);
 
-	char	**expected_expanded = (char *[]){"ls -l you ' '", "cat -e", "wc -l", NULL};
+// // 	char	**expected_expanded = (char *[]){"ls -l you ' '", "cat -e", "wc -l", NULL};
 
-	TEST_ASSERT_EQUAL_STRING_ARRAY(expected_expanded, expanded, 4);
+// // 	TEST_ASSERT_EQUAL_STRING_ARRAY(expected_expanded, expanded, 4);
 
-	arr_free(envp);
-	arr_free(split_tokens_trim_spaces);
-	arr_free(split_tokens);
-	arr_free(expanded);
-}
+// // 	arr_free(envp);
+// // 	arr_free(split_tokens_trim_spaces);
+// // 	arr_free(split_tokens);
+// // 	arr_free(expanded);
+// // }
 
-void	test_expansion_followed_dollarsign() {
+// void	test_expansion_followed_dollarsign() {
 
-	char	**split_tokens = arr_dup((const char **)(char *[]){"ls -l $somedir", "cat -e", "wc -l", NULL});
+// 	char	**split_tokens = arr_dup((const char **)(char *[]){"ls -l $somedir", "cat -e", "wc -l", NULL});
 
-	char	**split_tokens_trim_spaces = arr_trim(split_tokens, " ");
+// 	char	**split_tokens_trim_spaces = arr_trim(split_tokens, " ");
 
-	char	**envp = arr_dup((const char **)((char *[]){"PATH=/usr/bin", "HOME=/home/user", "USER=user", "somedir=$otherdir", "otherdir=mypath$", NULL}));
+// 	char	**envp = arr_dup((const char **)((char *[]){"PATH=/usr/bin", "HOME=/home/user", "USER=user", "somedir=$otherdir", "otherdir=mypath$", NULL}));
 
-	TEST_ASSERT_EQUAL_STRING("ls -l $somedir", split_tokens_trim_spaces[0]);
+// 	TEST_ASSERT_EQUAL_STRING("ls -l $somedir", split_tokens_trim_spaces[0]);
 
-	char	*tmp;
-	while (str_cchr(split_tokens_trim_spaces[0], '$') != 0)
-	{
-		tmp = expand_variables(split_tokens_trim_spaces[0], (const char **)envp);
-		TEST_ASSERT_NOT_NULL(tmp);
-		if (ft_strncmp(tmp, split_tokens_trim_spaces[0], ft_strlen(tmp)) == 0)
-		{
-			free(tmp);
-			break;
-		}
-		free(split_tokens_trim_spaces[0]);
-		split_tokens_trim_spaces[0] = tmp;
-	}
+// 	char	*tmp;
+// 	while (str_cchr(split_tokens_trim_spaces[0], '$') != 0)
+// 	{
+// 		tmp = expander(split_tokens_trim_spaces[0], (const char **)envp);
+// 		TEST_ASSERT_NOT_NULL(tmp);
+// 		if (ft_strncmp(tmp, split_tokens_trim_spaces[0], ft_strlen(tmp)) == 0)
+// 		{
+// 			free(tmp);
+// 			break;
+// 		}
+// 		free(split_tokens_trim_spaces[0]);
+// 		split_tokens_trim_spaces[0] = tmp;
+// 	}
 
-	char	**expected_expanded = (char *[]){"ls -l mypath$", "cat -e", "wc -l", NULL};
+// 	char	**expected_expanded = (char *[]){"ls -l mypath$", "cat -e", "wc -l", NULL};
 
-	TEST_ASSERT_EQUAL_STRING(expected_expanded[0], split_tokens_trim_spaces[0]);
+// 	TEST_ASSERT_EQUAL_STRING(expected_expanded[0], split_tokens_trim_spaces[0]);
 
-	arr_free(envp);
-	arr_free(split_tokens);
-	arr_free(split_tokens_trim_spaces);
-}
+// 	arr_free(envp);
+// 	arr_free(split_tokens);
+// 	arr_free(split_tokens_trim_spaces);
+// }
+
+// void	test_input_prefix_dollar() {
+// 	char	*line = "$$PAGER";
+// 	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
+
+// 	char	*expected_ret = "$true";
+
+// 	char	*actual = expander(line, (const char **)envp);
+// 	TEST_ASSERT_NOT_NULL(actual);
+// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+// 	printf("%s\n", actual);
+// 	free(actual);
+// }
+
+// void	test_input_prefix_dollar_two() {
+// 	char	*line = "$$PAGER";
+// 	char	*envp[] = {"PAGER=true", "TEST=false", NULL};
+// 	TEST_ASSERT_NOT_NULL(envp);
+
+// 	char	*expected_ret = "$true";
+
+// 	char	*actual = expander(line, (const char **)envp);
+
+// 	TEST_ASSERT_EQUAL_STRING(expected_ret, actual);
+// 	free(actual);
+// }

--- a/test/parser/test_quotes.c
+++ b/test/parser/test_quotes.c
@@ -3,8 +3,7 @@
 #include "support_parser.h"
 #include "checks_basic.c"
 #include "build_tokens.c"
-#include "expand_variables.c"
-#include "join_strings.c"
+#include "free_strjoin.c"
 #include "expander.c"
 #include "check_key.c"
 

--- a/test/parser/test_quotes.c
+++ b/test/parser/test_quotes.c
@@ -4,6 +4,9 @@
 #include "checks_basic.c"
 #include "build_tokens.c"
 #include "expand_variables.c"
+#include "join_strings.c"
+#include "expander.c"
+#include "check_key.c"
 
 void	test_nested_one() {
 	// "'"'"'test'"'"'"

--- a/test/parser/test_split_quotes.c
+++ b/test/parser/test_split_quotes.c
@@ -6,6 +6,9 @@
 #include "support_parser.h"
 #include "build_tokens.c"
 #include "expand_variables.c"
+#include "expander.c"
+#include "join_strings.c"
+#include "check_key.c"
 
 void	test_find_leaks() {
 	char	*input = strdup("echo | \"nopipes |\" | echo hello");

--- a/test/parser/test_split_quotes.c
+++ b/test/parser/test_split_quotes.c
@@ -7,7 +7,7 @@
 #include "build_tokens.c"
 #include "expand_variables.c"
 #include "expander.c"
-#include "join_strings.c"
+#include "free_strjoin.c"
 #include "check_key.c"
 
 void	test_find_leaks() {

--- a/test/support/support_tokens.c
+++ b/test/support/support_tokens.c
@@ -8,7 +8,7 @@
 #include "find_key.c"
 #include "print_arr_sep.c"
 #include "occurs.c"
-#include "expand_variables.c"
+#include "expander.c"
 
 #define TOKENS_H
 #define STRUCT_H
@@ -154,7 +154,7 @@ void	mock_convert_split_token_string_array_to_tokens(t_shell *shell)
 				shell->token[i].cmd_args[ii].quote = SINGLE;
 			while (str_cchr(shell->token[i].cmd_args[ii].elem, '$'))
 			{
-				tmp = expand_variables(shell->token[i].cmd_args[ii].elem, (const char **)shell->owned_envp);
+				tmp = expander(shell->token[i].cmd_args[ii].elem, (const char **)shell->owned_envp);
 				if (!tmp)
 					return ;
 				if (ft_strncmp(tmp, shell->token[i].cmd_args[ii].elem, ft_strlen(tmp)) == 0)

--- a/test/tokens/test_token_struct.c
+++ b/test/tokens/test_token_struct.c
@@ -15,9 +15,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include "support_tokens.c"
-#include "expander.c"
 #include "check_key.c"
-#include "join_strings.c"
+#include "free_strjoin.c"
 
 void	test_token_struct(void)
 {

--- a/test/tokens/test_token_struct.c
+++ b/test/tokens/test_token_struct.c
@@ -15,6 +15,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include "support_tokens.c"
+#include "expander.c"
+#include "check_key.c"
+#include "join_strings.c"
 
 void	test_token_struct(void)
 {

--- a/test/utils/test_join_strings.c
+++ b/test/utils/test_join_strings.c
@@ -1,0 +1,62 @@
+#include "join_strings.c"
+#include "unity.h"
+#include <string.h>
+
+void test_join_multiple_strings() {
+	char	*s1 = strdup("hello");
+	char	*s2 = strdup("world");
+	char	*s3 = strdup("!");
+
+	char	*joined = join_strings_free(3, s1, s2, s3);
+
+	TEST_ASSERT_EQUAL_STRING("helloworld!", joined);
+	free(joined);
+}
+
+void test_join_null() {
+	char	*s1 = strdup("hello");
+	char	*s2 = strdup("world");
+	char	*s3 = NULL;
+
+	char	*joined = join_strings_free(3, s1, s2, s3);
+
+	TEST_ASSERT_EQUAL_STRING(NULL, joined);
+}
+
+void test_join_null_two() {
+	char	*s1 = NULL;
+	char	*s2 = strdup("world");
+	char	*s3 = NULL;
+
+	char	*joined = join_strings_free(3, s1, s2, s3);
+
+	TEST_ASSERT_EQUAL_STRING(NULL, joined);
+}
+
+void test_join_null_three() {
+	char	*s1 = strdup("hello");
+	char	*s2 = strdup("world");
+	char	*s3 = NULL;
+
+	char	*joined = join_strings_free(3, s1, s2, s3);
+
+	TEST_ASSERT_EQUAL_STRING(NULL, joined);
+}
+
+void test_join_null_four() {
+	char	*s1 = NULL;
+	char	*s2 = strdup("world");
+	char	*s3 = strdup("!");
+
+	char	*joined = join_strings_free(3, s1, s2, s3);
+
+	TEST_ASSERT_EQUAL_STRING(NULL, joined);
+}
+
+void	test_free_multiple_items() {
+	char	*s1 = strdup("hello");
+	char	*s2 = strdup("world");
+	char	*s3 = strdup("!");
+
+	free_n(3, s1, s2, s3);
+}

--- a/test/utils/test_join_strings.c
+++ b/test/utils/test_join_strings.c
@@ -1,4 +1,4 @@
-#include "join_strings.c"
+#include "free_strjoin.c"
 #include "unity.h"
 #include <string.h>
 
@@ -7,7 +7,7 @@ void test_join_multiple_strings() {
 	char	*s2 = strdup("world");
 	char	*s3 = strdup("!");
 
-	char	*joined = join_strings_free(3, s1, s2, s3);
+	char	*joined = free_strjoin(3, s1, s2, s3);
 
 	TEST_ASSERT_EQUAL_STRING("helloworld!", joined);
 	free(joined);
@@ -18,7 +18,7 @@ void test_join_null() {
 	char	*s2 = strdup("world");
 	char	*s3 = NULL;
 
-	char	*joined = join_strings_free(3, s1, s2, s3);
+	char	*joined = free_strjoin(3, s1, s2, s3);
 
 	TEST_ASSERT_EQUAL_STRING(NULL, joined);
 }
@@ -28,7 +28,7 @@ void test_join_null_two() {
 	char	*s2 = strdup("world");
 	char	*s3 = NULL;
 
-	char	*joined = join_strings_free(3, s1, s2, s3);
+	char	*joined = free_strjoin(3, s1, s2, s3);
 
 	TEST_ASSERT_EQUAL_STRING(NULL, joined);
 }
@@ -38,7 +38,7 @@ void test_join_null_three() {
 	char	*s2 = strdup("world");
 	char	*s3 = NULL;
 
-	char	*joined = join_strings_free(3, s1, s2, s3);
+	char	*joined = free_strjoin(3, s1, s2, s3);
 
 	TEST_ASSERT_EQUAL_STRING(NULL, joined);
 }
@@ -48,7 +48,7 @@ void test_join_null_four() {
 	char	*s2 = strdup("world");
 	char	*s3 = strdup("!");
 
-	char	*joined = join_strings_free(3, s1, s2, s3);
+	char	*joined = free_strjoin(3, s1, s2, s3);
 
 	TEST_ASSERT_EQUAL_STRING(NULL, joined);
 }


### PR DESCRIPTION
- address issues with empty envars as outlined in issue
- fix issue with using `$` in expandable string & incorrect further expansion
e.g. `$KEY` -> `val` -> taken as nested key -> nonexistent -> replaced with empty string